### PR TITLE
Create ConfirmedPlaces for existing ConfirmedTrips

### DIFF
--- a/emission/analysis/userinput/matcher.py
+++ b/emission/analysis/userinput/matcher.py
@@ -93,6 +93,7 @@ def create_composite_objects(user_id):
         if "confirmed_place" not in ct["data"]:
             cleaned_place = esda.get_entry(esda.CLEANED_PLACE_KEY, ct["data"]["end_place"])
             confirmed_place_entry = create_confirmed_place_entry(ts, cleaned_place)
+            ts.insert(confirmed_place_entry)
             ct["data"]["confirmed_place"] = confirmed_place_entry["_id"]
             import emission.storage.timeseries.builtin_timeseries as estbt
             estbt.BuiltinTimeSeries.update(ct)

--- a/emission/analysis/userinput/matcher.py
+++ b/emission/analysis/userinput/matcher.py
@@ -93,8 +93,9 @@ def create_composite_objects(user_id):
         if "confirmed_place" not in ct["data"]:
             cleaned_place = esda.get_entry(esda.CLEANED_PLACE_KEY, ct["data"]["end_place"])
             confirmed_place_entry = create_confirmed_place_entry(ts, cleaned_place)
-            ts.insert(confirmed_place_entry)
-            ct["data"]["confirmed_place"] = confirmed_place_entry["_id"]
+            cpeid = ts.insert(confirmed_place_entry)
+            ct["data"]["confirmed_place"] = cpeid
+            logging.debug("Setting the confirmed_place key to the newly created id %s" % cpeid)
             import emission.storage.timeseries.builtin_timeseries as estbt
             estbt.BuiltinTimeSeries.update(ct)
 


### PR DESCRIPTION
Fixes https://github.com/e-mission/e-mission-docs/issues/865

Before confirmed_place was introduced, we created confirmed_trips without a confirmed_place. So, these existing entries are missing the confirmed_place ID for the place they should be linked to.
For those trips, we will generate a confirmed_place just-in-time and add its ID to the trip.

Once all trips have a confirmed_place, we can remove this code.