### PR TITLE
Rename confirmed_place in compositetrip to end_confirmed_place

### DIFF
--- a/emission/analysis/plotting/composite_trip_creation.py
+++ b/emission/analysis/plotting/composite_trip_creation.py
@@ -33,7 +33,7 @@ def create_composite_trip(ts, ct):
     # Thus, we are not going to consider it eligible for additions or user input,
     # and so untracked composite objects will not have a confirmed_place.
     if not isUntrackedTime:
-        composite_trip_dict["data"]["confirmed_place"] = eaum.get_confirmed_place_for_confirmed_trip(ct)
+        composite_trip_dict["data"]["end_confirmed_place"] = eaum.get_confirmed_place_for_confirmed_trip(ct)
     # later we will want to put section & modes in composite_trip as well
     composite_trip_entry = ecwe.Entry(composite_trip_dict)
     ts.insert(composite_trip_entry)

--- a/emission/core/wrapper/compositetrip.py
+++ b/emission/core/wrapper/compositetrip.py
@@ -12,7 +12,7 @@ import emission.core.wrapper.modeprediction as ecwm
 class Compositetrip(ecwc.Confirmedtrip):
     props = ecwc.Confirmedtrip.props
     props.update({#      # confirmedplace stuff
-                  "confirmed_place": ecwb.WrapperBase.Access.WORM, # object contains all properties for the destination confirmed_place object
+                  "end_confirmed_place": ecwb.WrapperBase.Access.WORM, # object contains all properties for the destination confirmed_place object
                   "locations": ecwb.WrapperBase.Access.WORM, # object containing cleaned location entries (max 100)
                   #      # sections stuff
                   "cleaned_section": ecwb.WrapperBase.Access.WORM,


### PR DESCRIPTION
matcher.py
- renamed insert for confirmed_place to end_confirmed_place

compositetrip.py
- renamed property for confirmed_place to end_confirmed_place

@shankari here is the correct PR, closing the old one (https://github.com/sebastianbarry/e-mission-server/pull/1)