### PR TITLE
Ensure that the composite trip metadata reflects the time that it was…

### DIFF
--- a/emission/analysis/plotting/composite_trip_creation.py
+++ b/emission/analysis/plotting/composite_trip_creation.py
@@ -24,21 +24,21 @@ def create_composite_trip(ts, ct):
         estbt.BuiltinTimeSeries.update(ct)
 
     logging.info("End place type for trip is %s" % type(ct['data']['end_place']))
-    composite_trip_dict = copy.copy(ct)
-    del composite_trip_dict["_id"]
-    composite_trip_dict["metadata"]["origin_key"] = ct["metadata"]["key"]
-    composite_trip_dict["metadata"]["key"] = "analysis/composite_trip"
-    composite_trip_dict["data"]["locations"] = get_locations_for_confirmed_trip(ct)
+    composite_trip_data = copy.copy(ct["data"])
+    origin_key = ct["metadata"]["key"]
+    logging.debug("Origin key for trip %s is %s" % (ct["_id"], origin_key))
+    composite_trip_data["locations"] = get_locations_for_confirmed_trip(ct)
     # The place that follows untracked time has a duration of 0.
     # Thus, we are not going to consider it eligible for additions or user input,
     # and so untracked composite objects will not have a confirmed_place.
     if not isUntrackedTime:
-        composite_trip_dict["data"]["confirmed_place"] = eaum.get_confirmed_place_for_confirmed_trip(ct)
+        composite_trip_data["confirmed_place"] = eaum.get_confirmed_place_for_confirmed_trip(ct)
     # later we will want to put section & modes in composite_trip as well
-    composite_trip_entry = ecwe.Entry(composite_trip_dict)
+    composite_trip_entry = ecwe.Entry.create_entry(ct["user_id"], "analysis/composite_trip", composite_trip_data)
+    composite_trip_entry["metadata"]["origin_key"] = origin_key
     ts.insert(composite_trip_entry)
 
-    return composite_trip_dict['data']['end_ts']
+    return composite_trip_data['end_ts']
 
 
 def create_composite_objects(user_id):

--- a/emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
+++ b/emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
@@ -52,6 +52,7 @@ import emission.core.common as ecc
 
 # Test imports
 import emission.tests.common as etc
+import time
 
 class TestPipelineRealData(unittest.TestCase):
     def setUp(self):
@@ -728,43 +729,53 @@ class TestPipelineRealData(unittest.TestCase):
         # should process smoothly into a continuous sequence of confirmed trips.
         # https://github.com/e-mission/e-mission-server/commit/df9d9f0844eedcf7405d88afe9da1b02ee365986
         dataFile = "emission/tests/data/real_examples/shankari_not_untracked_time_mar_21"
+        start_run = time.time()
         etc.setupRealExample(self, dataFile)
         etc.runIntakePipeline(self.testUUID)
+        end_run = time.time()
         ts = esta.TimeSeries.get_time_series(self.testUUID)
         composite_trips = list(ts.find_entries(["analysis/composite_trip"], None))
         for ct in composite_trips:
             # for this data, every composite trip should come from a confirmed trip,
             # NOT from untracked time
             self.assertEqual(ct['metadata']['origin_key'], 'analysis/confirmed_trip')
+            self.assertGreater(ct["metadata"]["write_ts"], start_run)
+            self.assertLessEqual(ct["metadata"]["write_ts"], end_run)
 
     def testShankariNotUntrackedTimeJan15(self):
         # This data has a reboot, so it should process with 1 instance of untracked time
         dataFile = "emission/tests/data/real_examples/shankari_untracked_time_jan_15_reboot_multi_day"
+        start_run = time.time()
         etc.setupRealExample(self, dataFile)
         etc.runIntakePipeline(self.testUUID)
+        end_run = time.time()
         ts = esta.TimeSeries.get_time_series(self.testUUID)
         composite_trips = list(ts.find_entries(["analysis/composite_trip"], None))
         countUntrackedTime = 0
         for ct in composite_trips:
             if ct['metadata']['origin_key'] == 'analysis/cleaned_untracked':
                 countUntrackedTime += 1
+            self.assertGreater(ct["metadata"]["write_ts"], start_run)
+            self.assertLessEqual(ct["metadata"]["write_ts"], end_run)
         self.assertEqual(countUntrackedTime, 1)
 
     def testShankariUntrackedTimeJul20(self):
         # This data has a large gap, so it should process with 1 instance of untracked time
         dataFile = "emission/tests/data/real_examples/shankari_untracked_time_jul_20_large_gap"
+        start_run = time.time()
         etc.setupRealExample(self, dataFile)
         etc.runIntakePipeline(self.testUUID)
+        end_run = time.time()
         ts = esta.TimeSeries.get_time_series(self.testUUID)
         composite_trips = list(ts.find_entries(["analysis/composite_trip"], None))
         countUntrackedTime = 0
         for ct in composite_trips:
+            logging.debug("composite trip metadata %s = " % ct['metadata'])
             if ct['metadata']['origin_key'] == 'analysis/cleaned_untracked':
-                cleanUntrackedTime += 1
-            elif ct['metadata']['origin_key'] == 'segmentation/raw_untracked':
-                rawUntrackedTime += 1
-        self.assertEqual(rawUntrackedTime, 1)
-        self.assertEqual(cleanUntrackedTime, 0)
+                countUntrackedTime += 1
+            self.assertGreater(ct["metadata"]["write_ts"], start_run)
+            self.assertLessEqual(ct["metadata"]["write_ts"], end_run)
+        self.assertEqual(countUntrackedTime, 0)
 
 if __name__ == '__main__':
     etc.configLogging()

--- a/emission/tests/data/real_examples/jack_untracked_time_2023-03-12.expected_composite_trips
+++ b/emission/tests/data/real_examples/jack_untracked_time_2023-03-12.expected_composite_trips
@@ -1,140 +1,6 @@
 [
     {
         "_id": {
-            "$oid": "6424f6cdfaa2035f6639303e"
-        },
-        "user_id": {
-            "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
-        },
-        "metadata": {
-            "key": "analysis/composite_trip",
-            "platform": "server",
-            "write_ts": 1680144071.062072,
-            "time_zone": "America/Los_Angeles",
-            "write_local_dt": {
-                "year": 2023,
-                "month": 3,
-                "day": 29,
-                "hour": 19,
-                "minute": 41,
-                "second": 11,
-                "weekday": 2,
-                "timezone": "America/Los_Angeles"
-            },
-            "write_fmt_time": "2023-03-29T19:41:11.062072-07:00",
-            "origin_key": "analysis/cleaned_untracked"
-        },
-        "data": {
-            "source": "DwellSegmentationTimeFilter",
-            "start_ts": 1678651111.264,
-            "start_local_dt": {
-                "year": 2023,
-                "month": 3,
-                "day": 12,
-                "hour": 15,
-                "minute": 58,
-                "second": 26,
-                "weekday": 6,
-                "timezone": "America/New_York"
-            },
-            "start_fmt_time": "2023-03-12T15:58:26.264000-04:00",
-            "start_loc": {
-                "type": "Point",
-                "coordinates": [
-                    -83.4604138,
-                    35.7326732
-                ]
-            },
-            "end_ts": 1678658742.268,
-            "end_local_dt": {
-                "year": 2023,
-                "month": 3,
-                "day": 12,
-                "hour": 18,
-                "minute": 5,
-                "second": 42,
-                "weekday": 6,
-                "timezone": "America/New_York"
-            },
-            "end_fmt_time": "2023-03-12T18:05:42.268000-04:00",
-            "end_loc": {
-                "type": "Point",
-                "coordinates": [
-                    -83.5054012,
-                    35.7158873
-                ]
-            },
-            "duration": 7631.003999948502,
-            "distance": 4469.499369190262,
-            "start_place": {
-                "$oid": "6424f6c9faa2035f66393021"
-            },
-            "end_place": {
-                "$oid": "6424f6c9faa2035f66393022"
-            },
-            "locations": [
-                {
-                    "_id": {
-                        "$oid": "6424f6c8faa2035f66393002"
-                    },
-                    "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
-                    },
-                    "metadata": {
-                        "key": "analysis/recreated_location",
-                        "platform": "server",
-                        "write_ts": 1680144072.338559,
-                        "time_zone": "America/Los_Angeles",
-                        "write_local_dt": {
-                            "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
-                            "weekday": 2,
-                            "timezone": "America/Los_Angeles"
-                        },
-                        "write_fmt_time": "2023-03-29T19:41:12.338559-07:00"
-                    },
-                    "data": {
-                        "latitude": 35.7158873,
-                        "longitude": -83.5054012,
-                        "loc": {
-                            "type": "Point",
-                            "coordinates": [
-                                -83.5054012,
-                                35.7158873
-                            ]
-                        },
-                        "ts": 1678658742.268,
-                        "local_dt": {
-                            "year": 2023,
-                            "month": 3,
-                            "day": 12,
-                            "hour": 18,
-                            "minute": 5,
-                            "second": 42,
-                            "weekday": 6,
-                            "timezone": "America/New_York"
-                        },
-                        "fmt_time": "2023-03-12T18:05:42.268000-04:00",
-                        "altitude": 393.02093505859375,
-                        "distance": 0.0,
-                        "speed": 0.0,
-                        "heading": 0.0,
-                        "idx": 0,
-                        "mode": 4,
-                        "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
-                        }
-                    }
-                }
-            ]
-        }
-    },
-    {
-        "_id": {
             "$oid": "6424f6cdfaa2035f6639303d"
         },
         "user_id": {
@@ -6006,6 +5872,82 @@
                     }
                 }
             ]
+        }
+    },
+    {
+        "_id": {
+            "$oid": "6424f6cdfaa2035f6639303e"
+        },
+        "user_id": {
+            "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+        },
+        "metadata": {
+            "key": "analysis/composite_trip",
+            "platform": "server",
+            "write_ts": 1680144071.062072,
+            "time_zone": "America/Los_Angeles",
+            "write_local_dt": {
+                "year": 2023,
+                "month": 3,
+                "day": 29,
+                "hour": 19,
+                "minute": 41,
+                "second": 11,
+                "weekday": 2,
+                "timezone": "America/Los_Angeles"
+            },
+            "write_fmt_time": "2023-03-29T19:41:11.062072-07:00",
+            "origin_key": "analysis/cleaned_untracked"
+        },
+        "data": {
+            "source": "DwellSegmentationTimeFilter",
+            "start_ts": 1678651111.264,
+            "start_local_dt": {
+                "year": 2023,
+                "month": 3,
+                "day": 12,
+                "hour": 15,
+                "minute": 58,
+                "second": 26,
+                "weekday": 6,
+                "timezone": "America/New_York"
+            },
+            "start_fmt_time": "2023-03-12T15:58:26.264000-04:00",
+            "start_loc": {
+                "type": "Point",
+                "coordinates": [
+                    -83.4604138,
+                    35.7326732
+                ]
+            },
+            "end_ts": 1678658742.268,
+            "end_local_dt": {
+                "year": 2023,
+                "month": 3,
+                "day": 12,
+                "hour": 18,
+                "minute": 5,
+                "second": 42,
+                "weekday": 6,
+                "timezone": "America/New_York"
+            },
+            "end_fmt_time": "2023-03-12T18:05:42.268000-04:00",
+            "end_loc": {
+                "type": "Point",
+                "coordinates": [
+                    -83.5054012,
+                    35.7158873
+                ]
+            },
+            "duration": 7631.003999948502,
+            "distance": 4469.499369190262,
+            "start_place": {
+                "$oid": "6424f6c9faa2035f66393021"
+            },
+            "end_place": {
+                "$oid": "6424f6c9faa2035f66393022"
+            },
+            "locations": []
         }
     },
     {


### PR DESCRIPTION
… created

Bonus fix: use the existing `ecwe.Entry.create_entry` to fill in the new entry instead of manually recreating

Also enhance the tests to check for the metadata

Bonus fix: Remove incorrect check for `testShankariUntrackedTimeJul20` The composite trip code only checks for `cleaned_untracked`, so `raw_untracked` segments will not show up as composite trips, so we do not expect to find one `raw_untracked` time entry

Testing done:

Added intentional error to one of the tests (write_ts less than start), it failed

```
====================================================================== FAIL: testShankariNotUntrackedTimeJan15 (__main__.TestPipelineRealData) ---------------------------------------------------------------------- Traceback (most recent call last):
  File "emission/tests/analysisTests/intakeTests/TestPipelineRealData.py", line 756, in testShankariNotUntrackedTimeJan15
    self.assertLess(ct["metadata"]["write_ts"], start_run)
AssertionError: 1680716084.451522 not less than 1680716064.349642

----------------------------------------------------------------------
```

Only one pipeline test fails (fixing in the next commit)

```
./e-mission-py.bash emission/tests/analysisTests/intakeTests/TestPipelineRealData.py

======================================================================
FAIL: testJackUntrackedTimeMar12 (__main__.TestPipelineRealData)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "emission/tests/analysisTests/intakeTests/TestPipelineRealData.py", line 723, in testJackUntrackedTimeMar12
    self.compare_composite_objects(composite_trips[i], expected_trips[i])
  File "emission/tests/analysisTests/intakeTests/TestPipelineRealData.py", line 703, in compare_composite_objects
    self.assertEqual(ct['data']['start_ts'], et['data']['start_ts'])
AssertionError: 1678642210.9015162 != 1678651111.264

----------------------------------------------------------------------
Ran 1 test in 21.336s
```