### PR TITLE
update expected composite trips for test JackMar12

### DIFF
--- a/emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
+++ b/emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
@@ -702,12 +702,12 @@ class TestPipelineRealData(unittest.TestCase):
     def compare_composite_objects(self, ct, et):
         self.assertEqual(ct['data']['start_ts'], et['data']['start_ts'])
         self.assertEqual(ct['data']['end_ts'], et['data']['end_ts'])
-        if 'confirmed_place' in et['data']:
-            self.assertEqual(ct['data']['confirmed_place']['data']['enter_ts'],
-                                et['data']['confirmed_place']['data']['enter_ts'])
-            if 'exit_ts' in et['data']['confirmed_place']:
-                self.assertEqual(ct['data']['confirmed_place']['exit_ts'],
-                                    et['data']['confirmed_place']['exit_ts'])
+        if 'end_confirmed_place' in et['data']:
+            self.assertEqual(ct['data']['end_confirmed_place']['data']['enter_ts'],
+                                et['data']['end_confirmed_place']['data']['enter_ts'])
+            if 'exit_ts' in et['data']['end_confirmed_place']:
+                self.assertEqual(ct['data']['end_confirmed_place']['exit_ts'],
+                                    et['data']['end_confirmed_place']['exit_ts'])
         self.assertEqual(len(ct['data']['locations']), len(et['data']['locations']))
 
     def testJackUntrackedTimeMar12(self):

--- a/emission/tests/data/real_examples/jack_untracked_time_2023-03-12.expected_composite_trips
+++ b/emission/tests/data/real_examples/jack_untracked_time_2023-03-12.expected_composite_trips
@@ -1,27 +1,5680 @@
 [
     {
         "_id": {
-            "$oid": "6424f6cdfaa2035f6639303d"
+            "$oid": "642df8ad7fb841b12dafa80d"
         },
         "user_id": {
-            "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+            "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
         },
         "metadata": {
             "key": "analysis/composite_trip",
             "platform": "server",
-            "write_ts": 1680144074.71583,
+            "write_ts": 1680734381.67915,
             "time_zone": "America/Los_Angeles",
             "write_local_dt": {
                 "year": 2023,
-                "month": 3,
-                "day": 29,
-                "hour": 19,
-                "minute": 41,
-                "second": 14,
+                "month": 4,
+                "day": 5,
+                "hour": 15,
+                "minute": 39,
+                "second": 41,
                 "weekday": 2,
                 "timezone": "America/Los_Angeles"
             },
-            "write_fmt_time": "2023-03-29T19:41:14.715830-07:00",
+            "write_fmt_time": "2023-04-05T15:39:41.679150-07:00",
+            "origin_key": "analysis/confirmed_trip"
+        },
+        "data": {
+            "source": "DwellSegmentationTimeFilter",
+            "end_ts": 1678641399.257,
+            "end_local_dt": {
+                "year": 2023,
+                "month": 3,
+                "day": 12,
+                "hour": 13,
+                "minute": 16,
+                "second": 39,
+                "weekday": 6,
+                "timezone": "America/New_York"
+            },
+            "end_fmt_time": "2023-03-12T13:16:39.257000-04:00",
+            "end_loc": {
+                "type": "Point",
+                "coordinates": [
+                    -84.1162207,
+                    36.9776568
+                ]
+            },
+            "raw_trip": {
+                "$oid": "642df8a27fb841b12dafa56f"
+            },
+            "start_ts": 1678632794.566166,
+            "start_local_dt": {
+                "year": 2023,
+                "month": 3,
+                "day": 12,
+                "hour": 10,
+                "minute": 53,
+                "second": 14,
+                "weekday": 6,
+                "timezone": "America/New_York"
+            },
+            "start_fmt_time": "2023-03-12T10:53:14.566166-04:00",
+            "start_loc": {
+                "type": "Point",
+                "coordinates": [
+                    -84.7888212,
+                    39.2625805
+                ]
+            },
+            "duration": 8604.69083404541,
+            "distance": 291529.0171651621,
+            "start_place": {
+                "$oid": "642df8a97fb841b12dafa7ee"
+            },
+            "end_place": {
+                "$oid": "642df8aa7fb841b12dafa7f0"
+            },
+            "cleaned_trip": {
+                "$oid": "642df8a57fb841b12dafa580"
+            },
+            "inferred_labels": [],
+            "inferred_trip": {
+                "$oid": "642df8aa7fb841b12dafa7f7"
+            },
+            "expectation": {
+                "to_label": true
+            },
+            "confidence_threshold": 0.55,
+            "expected_trip": {
+                "$oid": "642df8ab7fb841b12dafa801"
+            },
+            "user_input": {},
+            "additions": [],
+            "confirmed_place": {
+                "$oid": "642df8ab7fb841b12dafa805"
+            },
+            "locations": [
+                {
+                    "_id": {
+                        "$oid": "642df8a97fb841b12dafa7ef"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734377.845074,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:37.845074-07:00"
+                    },
+                    "data": {
+                        "accuracy": 18.224,
+                        "altitude": 137.8626708984375,
+                        "elapsedRealtimeNanos": 164225292669207,
+                        "filter": "time",
+                        "fmt_time": "2023-03-12T10:53:14.566166-04:00",
+                        "latitude": 39.2625805,
+                        "longitude": -84.7888212,
+                        "sensed_speed": 0,
+                        "ts": 1678632794.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 10,
+                            "minute": 53,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.7888212,
+                                39.2625805
+                            ]
+                        },
+                        "heading": 0,
+                        "speed": 0,
+                        "distance": 0,
+                        "mode": 11,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa585"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.6583412,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.658341-07:00"
+                    },
+                    "data": {
+                        "latitude": 39.24549621958169,
+                        "longitude": -84.77752559374292,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.77752559374292,
+                                39.24549621958169
+                            ]
+                        },
+                        "ts": 1678632884.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 10,
+                            "minute": 54,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T10:54:44.566166-04:00",
+                        "altitude": 178.9377815513805,
+                        "distance": 1062.2876440564787,
+                        "speed": 35.409588135215955,
+                        "heading": 152.80091350325264,
+                        "idx": 2,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa588"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.660314,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.660314-07:00"
+                    },
+                    "data": {
+                        "latitude": 39.22000479895423,
+                        "longitude": -84.76061008435732,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.76061008435732,
+                                39.22000479895423
+                            ]
+                        },
+                        "ts": 1678632974.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 10,
+                            "minute": 56,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T10:56:14.566166-04:00",
+                        "altitude": 189.38144118313878,
+                        "distance": 1062.3682993611853,
+                        "speed": 35.41227664537284,
+                        "heading": 152.79245069778366,
+                        "idx": 5,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa58b"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.662255,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.662255-07:00"
+                    },
+                    "data": {
+                        "latitude": 39.19558080665212,
+                        "longitude": -84.77028516638819,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.77028516638819,
+                                39.19558080665212
+                            ]
+                        },
+                        "ts": 1678633064.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 10,
+                            "minute": 57,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T10:57:44.566166-04:00",
+                        "altitude": 130.94517838963085,
+                        "distance": 1101.834169417856,
+                        "speed": 36.72780564726187,
+                        "heading": -152.3904720144624,
+                        "idx": 8,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa58e"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.6637921,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.663792-07:00"
+                    },
+                    "data": {
+                        "latitude": 39.17961838214106,
+                        "longitude": -84.79875594324929,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.79875594324929,
+                                39.17961838214106
+                            ]
+                        },
+                        "ts": 1678633154.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 10,
+                            "minute": 59,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T10:59:14.566166-04:00",
+                        "altitude": 96.32001073844754,
+                        "distance": 995.0489143082992,
+                        "speed": 33.168297143609976,
+                        "heading": -119.79291552236387,
+                        "idx": 11,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa591"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.665083,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.665083-07:00"
+                    },
+                    "data": {
+                        "latitude": 39.153479928446735,
+                        "longitude": -84.81731903319849,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.81731903319849,
+                                39.153479928446735
+                            ]
+                        },
+                        "ts": 1678633244.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 0,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:00:44.566166-04:00",
+                        "altitude": 121.55330570844276,
+                        "distance": 1101.6366298769567,
+                        "speed": 36.721220995898555,
+                        "heading": -148.5512219432876,
+                        "idx": 14,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa594"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.666222,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.666222-07:00"
+                    },
+                    "data": {
+                        "latitude": 39.1281436594605,
+                        "longitude": -84.83371375883989,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.83371375883989,
+                                39.1281436594605
+                            ]
+                        },
+                        "ts": 1678633334.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 2,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:02:14.566166-04:00",
+                        "altitude": 126.94250921898737,
+                        "distance": 1057.604197624379,
+                        "speed": 35.253473254145966,
+                        "heading": -160.74899765130138,
+                        "idx": 17,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa597"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.667338,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.667338-07:00"
+                    },
+                    "data": {
+                        "latitude": 39.102703624128544,
+                        "longitude": -84.82479139865904,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.82479139865904,
+                                39.102703624128544
+                            ]
+                        },
+                        "ts": 1678633424.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 3,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:03:44.566166-04:00",
+                        "altitude": 144.83264039523888,
+                        "distance": 883.9446338738095,
+                        "speed": 29.46482112912698,
+                        "heading": 146.9338602433676,
+                        "idx": 20,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa59a"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.668303,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.668303-07:00"
+                    },
+                    "data": {
+                        "latitude": 39.08888705813327,
+                        "longitude": -84.79532288395754,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.79532288395754,
+                                39.08888705813327
+                            ]
+                        },
+                        "ts": 1678633514.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 5,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:05:14.566166-04:00",
+                        "altitude": 197.81239963353502,
+                        "distance": 1079.0797135664209,
+                        "speed": 35.96932378554736,
+                        "heading": 109.1127226359278,
+                        "idx": 23,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa59d"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.669251,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.669251-07:00"
+                    },
+                    "data": {
+                        "latitude": 39.08795753933297,
+                        "longitude": -84.76014534317488,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.76014534317488,
+                                39.08795753933297
+                            ]
+                        },
+                        "ts": 1678633604.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 6,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:06:44.566166-04:00",
+                        "altitude": 200.5319150220778,
+                        "distance": 1072.995296254861,
+                        "speed": 35.76650987516203,
+                        "heading": 91.74415475986191,
+                        "idx": 26,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5a0"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.670395,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.670395-07:00"
+                    },
+                    "data": {
+                        "latitude": 39.08125031721781,
+                        "longitude": -84.72407530379405,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.72407530379405,
+                                39.08125031721781
+                            ]
+                        },
+                        "ts": 1678633694.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 8,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:08:14.566166-04:00",
+                        "altitude": 231.47717130137536,
+                        "distance": 1033.3587290414227,
+                        "speed": 34.44529096804742,
+                        "heading": 102.35412081649953,
+                        "idx": 29,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5a3"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.671387,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.671387-07:00"
+                    },
+                    "data": {
+                        "latitude": 39.07801341631519,
+                        "longitude": -84.69027957841905,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.69027957841905,
+                                39.07801341631519
+                            ]
+                        },
+                        "ts": 1678633784.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 9,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:09:44.566166-04:00",
+                        "altitude": 194.954227057645,
+                        "distance": 1029.1085493324047,
+                        "speed": 34.30361831108016,
+                        "heading": 108.43711137901681,
+                        "idx": 32,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5a6"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.673383,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.673383-07:00"
+                    },
+                    "data": {
+                        "latitude": 39.07025035051584,
+                        "longitude": -84.65504723251887,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.65504723251887,
+                                39.07025035051584
+                            ]
+                        },
+                        "ts": 1678633874.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 11,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:11:14.566166-04:00",
+                        "altitude": 225.33702094876,
+                        "distance": 990.9667736279441,
+                        "speed": 33.032225787598136,
+                        "heading": 106.96418949602564,
+                        "idx": 35,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5a9"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.674927,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.674927-07:00"
+                    },
+                    "data": {
+                        "latitude": 39.055432875486254,
+                        "longitude": -84.63013908012127,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.63013908012127,
+                                39.055432875486254
+                            ]
+                        },
+                        "ts": 1678633964.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 12,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:12:44.566166-04:00",
+                        "altitude": 233.12364792379114,
+                        "distance": 899.3760286125303,
+                        "speed": 29.979200953751008,
+                        "heading": 118.40755098131841,
+                        "idx": 38,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5ac"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.6759949,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.675995-07:00"
+                    },
+                    "data": {
+                        "latitude": 39.0409888635965,
+                        "longitude": -84.61091591427035,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.61091591427035,
+                                39.0409888635965
+                            ]
+                        },
+                        "ts": 1678634054.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 14,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:14:14.566166-04:00",
+                        "altitude": 234.43531798954658,
+                        "distance": 715.6403499425951,
+                        "speed": 23.854678331419837,
+                        "heading": 138.28666139548153,
+                        "idx": 41,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5af"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.677184,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.677184-07:00"
+                    },
+                    "data": {
+                        "latitude": 39.02856469705388,
+                        "longitude": -84.61064778995467,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.61064778995467,
+                                39.02856469705388
+                            ]
+                        },
+                        "ts": 1678634144.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 15,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:15:44.566166-04:00",
+                        "altitude": 240.11794975541778,
+                        "distance": 638.920257350796,
+                        "speed": 21.2973419116932,
+                        "heading": -134.88999516680977,
+                        "idx": 44,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5b2"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.678289,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.678289-07:00"
+                    },
+                    "data": {
+                        "latitude": 39.01333199127216,
+                        "longitude": -84.63049245116653,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.63049245116653,
+                                39.01333199127216
+                            ]
+                        },
+                        "ts": 1678634234.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 17,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:17:14.566166-04:00",
+                        "altitude": 219.97938944915484,
+                        "distance": 831.4017640531399,
+                        "speed": 27.713392135104662,
+                        "heading": -128.6308145780553,
+                        "idx": 47,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5b5"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.6793249,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.679325-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.993070367402666,
+                        "longitude": -84.64503510915299,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.64503510915299,
+                                38.993070367402666
+                            ]
+                        },
+                        "ts": 1678634324.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 18,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:18:44.566166-04:00",
+                        "altitude": 252.18638583580906,
+                        "distance": 961.277299659979,
+                        "speed": 32.04257665533263,
+                        "heading": 179.79207944788257,
+                        "idx": 50,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5b8"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.6804621,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.680462-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.96484235980689,
+                        "longitude": -84.63537286176681,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.63537286176681,
+                                38.96484235980689
+                            ]
+                        },
+                        "ts": 1678634414.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 20,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:20:14.566166-04:00",
+                        "altitude": 306.6137873953211,
+                        "distance": 1106.9578167351187,
+                        "speed": 36.89859389117063,
+                        "heading": 168.84771895232683,
+                        "idx": 53,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5bb"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.681456,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.681456-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.93448672497926,
+                        "longitude": -84.6315442155558,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.6315442155558,
+                                38.93448672497926
+                            ]
+                        },
+                        "ts": 1678634504.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 21,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:21:44.566166-04:00",
+                        "altitude": 235.07378146915968,
+                        "distance": 1121.0427346090107,
+                        "speed": 37.36809115363369,
+                        "heading": 173.96614151070574,
+                        "idx": 56,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5be"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.682431,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.682431-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.90471865375652,
+                        "longitude": -84.62782148545547,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.62782148545547,
+                                38.90471865375652
+                            ]
+                        },
+                        "ts": 1678634594.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 23,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:23:14.566166-04:00",
+                        "altitude": 232.5954308421422,
+                        "distance": 1067.5463538946606,
+                        "speed": 35.584878463155356,
+                        "heading": 174.73561632095272,
+                        "idx": 59,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5c1"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.6834052,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.683405-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.875043279618026,
+                        "longitude": -84.62478785756062,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.62478785756062,
+                                38.875043279618026
+                            ]
+                        },
+                        "ts": 1678634684.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 24,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:24:44.566166-04:00",
+                        "altitude": 242.07813787927245,
+                        "distance": 1121.7621244933744,
+                        "speed": 37.39207081644581,
+                        "heading": 174.71271933442355,
+                        "idx": 62,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5c4"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.684534,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.684534-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.84620390514235,
+                        "longitude": -84.61988616013514,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.61988616013514,
+                                38.84620390514235
+                            ]
+                        },
+                        "ts": 1678634774.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 26,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:26:14.566166-04:00",
+                        "altitude": 236.57667004904044,
+                        "distance": 1061.8588183726574,
+                        "speed": 35.39529394575525,
+                        "heading": 166.83816945100213,
+                        "idx": 65,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5c7"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.6855009,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.685501-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.82241746506728,
+                        "longitude": -84.60042061818274,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.60042061818274,
+                                38.82241746506728
+                            ]
+                        },
+                        "ts": 1678634864.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 27,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:27:44.566166-04:00",
+                        "altitude": 254.30202370269768,
+                        "distance": 1023.8612801869743,
+                        "speed": 34.12870933956581,
+                        "heading": 161.57772785594898,
+                        "idx": 68,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5ca"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.686461,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.686461-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.793236784404826,
+                        "longitude": -84.6046995271237,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.6046995271237,
+                                38.793236784404826
+                            ]
+                        },
+                        "ts": 1678634954.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 29,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:29:14.566166-04:00",
+                        "altitude": 237.5887266022094,
+                        "distance": 1085.4703062100969,
+                        "speed": 36.18234354033656,
+                        "heading": -172.23061775382382,
+                        "idx": 71,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5cd"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.6874208,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.687421-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.76598444751353,
+                        "longitude": -84.60937887861948,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.60937887861948,
+                                38.76598444751353
+                            ]
+                        },
+                        "ts": 1678635044.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 30,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:30:44.566166-04:00",
+                        "altitude": 213.60248064380139,
+                        "distance": 1057.4558341656898,
+                        "speed": 35.24852780552299,
+                        "heading": 170.47570658026376,
+                        "idx": 74,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5d0"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.6890738,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.689074-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.73763292643783,
+                        "longitude": -84.60497887031103,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.60497887031103,
+                                38.73763292643783
+                            ]
+                        },
+                        "ts": 1678635134.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 32,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:32:14.566166-04:00",
+                        "altitude": 234.29997854518393,
+                        "distance": 1051.0934340876788,
+                        "speed": 35.03644780292263,
+                        "heading": 175.4784568573502,
+                        "idx": 77,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5d3"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.691257,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.691257-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.70840051262806,
+                        "longitude": -84.60276900508235,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.60276900508235,
+                                38.70840051262806
+                            ]
+                        },
+                        "ts": 1678635224.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 33,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:33:44.566166-04:00",
+                        "altitude": 228.51198469977314,
+                        "distance": 1121.1999590398386,
+                        "speed": 37.37333196799462,
+                        "heading": 173.89188906925224,
+                        "idx": 80,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5d6"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.692653,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.692653-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.6804189694491,
+                        "longitude": -84.60150913105144,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.60150913105144,
+                                38.6804189694491
+                            ]
+                        },
+                        "ts": 1678635314.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 35,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:35:14.566166-04:00",
+                        "altitude": 247.85848495018732,
+                        "distance": 1009.6886335886409,
+                        "speed": 33.656287786288026,
+                        "heading": 179.66891003547707,
+                        "idx": 83,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5d9"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.6937249,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.693725-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.657365485165236,
+                        "longitude": -84.58687734857116,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.58687734857116,
+                                38.657365485165236
+                            ]
+                        },
+                        "ts": 1678635404.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 36,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:36:44.566166-04:00",
+                        "altitude": 227.2666293460207,
+                        "distance": 966.1620257228292,
+                        "speed": 32.20540085742764,
+                        "heading": 157.94249158827427,
+                        "idx": 86,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5dc"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.694977,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.694977-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.63051296185071,
+                        "longitude": -84.57688064052128,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.57688064052128,
+                                38.63051296185071
+                            ]
+                        },
+                        "ts": 1678635494.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 38,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:38:14.566166-04:00",
+                        "altitude": 239.3811796089099,
+                        "distance": 1038.571334536873,
+                        "speed": 34.61904448456244,
+                        "heading": 147.4211349263279,
+                        "idx": 89,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5df"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.695976,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.695976-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.60247865998797,
+                        "longitude": -84.58010114043807,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.58010114043807,
+                                38.60247865998797
+                            ]
+                        },
+                        "ts": 1678635584.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 39,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:39:44.566166-04:00",
+                        "altitude": 242.26618371488848,
+                        "distance": 1150.7099256486465,
+                        "speed": 38.35699752162155,
+                        "heading": -158.02051832841164,
+                        "idx": 92,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5e2"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.6969779,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.696978-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.57370074076747,
+                        "longitude": -84.59210121223052,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.59210121223052,
+                                38.57370074076747
+                            ]
+                        },
+                        "ts": 1678635674.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 41,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:41:14.566166-04:00",
+                        "altitude": 244.4609186509599,
+                        "distance": 1105.59488151804,
+                        "speed": 36.853162717268,
+                        "heading": -162.7505427501974,
+                        "idx": 95,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5e5"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.6979399,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.697940-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.5465140856871,
+                        "longitude": -84.59685400246511,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.59685400246511,
+                                38.5465140856871
+                            ]
+                        },
+                        "ts": 1678635764.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 42,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:42:44.566166-04:00",
+                        "altitude": 237.5904717428348,
+                        "distance": 1003.2163413165525,
+                        "speed": 33.44054471055175,
+                        "heading": 175.55040456455237,
+                        "idx": 98,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5e8"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.698892,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.698892-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.51948954896964,
+                        "longitude": -84.58800572736118,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.58800572736118,
+                                38.51948954896964
+                            ]
+                        },
+                        "ts": 1678635854.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 44,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:44:14.566166-04:00",
+                        "altitude": 271.40670280136305,
+                        "distance": 1058.9181395944356,
+                        "speed": 35.29727131981452,
+                        "heading": 178.99847485953438,
+                        "idx": 101,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5eb"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.699837,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.699837-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.49053344224028,
+                        "longitude": -84.58646517237614,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.58646517237614,
+                                38.49053344224028
+                            ]
+                        },
+                        "ts": 1678635944.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 45,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:45:44.566166-04:00",
+                        "altitude": 240.47277724193904,
+                        "distance": 1085.7777684261073,
+                        "speed": 36.192592280870244,
+                        "heading": 169.82994673975506,
+                        "idx": 104,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5ee"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.7011719,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.701172-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.46182861451943,
+                        "longitude": -84.57696168509918,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.57696168509918,
+                                38.46182861451943
+                            ]
+                        },
+                        "ts": 1678636034.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 47,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:47:14.566166-04:00",
+                        "altitude": 214.1585984516361,
+                        "distance": 1053.675281177522,
+                        "speed": 35.12250937258407,
+                        "heading": 168.52674419575277,
+                        "idx": 107,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5f1"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.70228,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.702280-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.43475978926568,
+                        "longitude": -84.57240381368284,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.57240381368284,
+                                38.43475978926568
+                            ]
+                        },
+                        "ts": 1678636124.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 48,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:48:44.566166-04:00",
+                        "altitude": 244.16938003160413,
+                        "distance": 974.1067956867727,
+                        "speed": 32.470226522892425,
+                        "heading": -173.4907824685082,
+                        "idx": 110,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5f4"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.703306,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.703306-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.40769132852375,
+                        "longitude": -84.57838966308061,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.57838966308061,
+                                38.40769132852375
+                            ]
+                        },
+                        "ts": 1678636214.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 50,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:50:14.566166-04:00",
+                        "altitude": 226.7782313491267,
+                        "distance": 996.145652298753,
+                        "speed": 33.2048550766251,
+                        "heading": 172.17966949912827,
+                        "idx": 113,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5f7"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.704808,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.704808-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.378795091848595,
+                        "longitude": -84.57123394618341,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.57123394618341,
+                                38.378795091848595
+                            ]
+                        },
+                        "ts": 1678636304.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 51,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:51:44.566166-04:00",
+                        "altitude": 217.01788768025241,
+                        "distance": 1078.202284007639,
+                        "speed": 35.940076133587965,
+                        "heading": 162.82594239182197,
+                        "idx": 116,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5fa"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.706517,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.706517-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.34959801306411,
+                        "longitude": -84.56818560093798,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.56818560093798,
+                                38.34959801306411
+                            ]
+                        },
+                        "ts": 1678636394.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 53,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:53:14.566166-04:00",
+                        "altitude": 229.43086311229456,
+                        "distance": 1077.1064075056129,
+                        "speed": 35.90354691685376,
+                        "heading": -177.8811739876962,
+                        "idx": 119,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa5fd"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.709172,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.709172-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.323247798711165,
+                        "longitude": -84.55967311377317,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.55967311377317,
+                                38.323247798711165
+                            ]
+                        },
+                        "ts": 1678636484.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 54,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:54:44.566166-04:00",
+                        "altitude": 252.19639504474944,
+                        "distance": 1009.56314719957,
+                        "speed": 33.65210490665233,
+                        "heading": 155.16788050823683,
+                        "idx": 122,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa600"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.710952,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.710952-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.2935348087777,
+                        "longitude": -84.55883651040635,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.55883651040635,
+                                38.2935348087777
+                            ]
+                        },
+                        "ts": 1678636574.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 56,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:56:14.566166-04:00",
+                        "altitude": 238.67185796325646,
+                        "distance": 1160.3279091942309,
+                        "speed": 38.67759697314103,
+                        "heading": 179.8837874481678,
+                        "idx": 125,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa603"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.7127628,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.712763-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.26368009226701,
+                        "longitude": -84.55302382737477,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.55302382737477,
+                                38.26368009226701
+                            ]
+                        },
+                        "ts": 1678636664.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 57,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:57:44.566166-04:00",
+                        "altitude": 214.20954137139105,
+                        "distance": 1106.2173660162257,
+                        "speed": 36.87391220054086,
+                        "heading": 164.56273803837172,
+                        "idx": 128,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa606"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.714697,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.714697-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.2351553470277,
+                        "longitude": -84.54265304763348,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.54265304763348,
+                                38.2351553470277
+                            ]
+                        },
+                        "ts": 1678636754.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 11,
+                            "minute": 59,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T11:59:14.566166-04:00",
+                        "altitude": 237.68137235634154,
+                        "distance": 1095.9940443174637,
+                        "speed": 36.533134810582126,
+                        "heading": 163.93785563891103,
+                        "idx": 131,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa609"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.716851,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.716851-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.20804021994125,
+                        "longitude": -84.53116100740044,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.53116100740044,
+                                38.20804021994125
+                            ]
+                        },
+                        "ts": 1678636844.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 0,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:00:44.566166-04:00",
+                        "altitude": 221.3221934868464,
+                        "distance": 1035.8885210471303,
+                        "speed": 34.52961736823768,
+                        "heading": 161.61363653406357,
+                        "idx": 134,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa60c"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.718584,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.718584-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.182015090406686,
+                        "longitude": -84.52977165264053,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.52977165264053,
+                                38.182015090406686
+                            ]
+                        },
+                        "ts": 1678636934.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 2,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:02:14.566166-04:00",
+                        "altitude": 213.75608244145965,
+                        "distance": 986.8732329596011,
+                        "speed": 32.8957744319867,
+                        "heading": -160.8924079117413,
+                        "idx": 137,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa60f"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.7202802,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.720280-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.154338678659684,
+                        "longitude": -84.53265115312054,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.53265115312054,
+                                38.154338678659684
+                            ]
+                        },
+                        "ts": 1678637024.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 3,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:03:44.566166-04:00",
+                        "altitude": 240.13337474336345,
+                        "distance": 1103.8023330044946,
+                        "speed": 36.79341110014982,
+                        "heading": 167.50673276704143,
+                        "idx": 140,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa612"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.722452,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.722452-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.125583407420265,
+                        "longitude": -84.52817712007399,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.52817712007399,
+                                38.125583407420265
+                            ]
+                        },
+                        "ts": 1678637114.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 5,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:05:14.566166-04:00",
+                        "altitude": 249.65047998997954,
+                        "distance": 1099.950200338439,
+                        "speed": 36.665006677947964,
+                        "heading": 173.0567322761635,
+                        "idx": 143,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa615"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.7243788,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.724379-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.10980749002335,
+                        "longitude": -84.50700701682861,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.50700701682861,
+                                38.10980749002335
+                            ]
+                        },
+                        "ts": 1678637204.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 6,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:06:44.566166-04:00",
+                        "altitude": 232.1996374811705,
+                        "distance": 994.8578324387736,
+                        "speed": 33.16192774795912,
+                        "heading": 111.36718646125928,
+                        "idx": 146,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa618"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.726203,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.726203-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.095775383796884,
+                        "longitude": -84.47821463080325,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.47821463080325,
+                                38.095775383796884
+                            ]
+                        },
+                        "ts": 1678637294.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 8,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:08:14.566166-04:00",
+                        "altitude": 238.5842053759336,
+                        "distance": 898.5655009460299,
+                        "speed": 29.952183364867665,
+                        "heading": 123.14519213736439,
+                        "idx": 149,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa61b"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.728585,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.728585-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.07905971845673,
+                        "longitude": -84.45851258441763,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.45851258441763,
+                                38.07905971845673
+                            ]
+                        },
+                        "ts": 1678637384.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 9,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:09:44.566166-04:00",
+                        "altitude": 254.28812036658584,
+                        "distance": 871.2329752299835,
+                        "speed": 29.041099174332782,
+                        "heading": 148.04092331924187,
+                        "idx": 152,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa61e"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.730387,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.730387-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.06228396667604,
+                        "longitude": -84.43943318978438,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.43943318978438,
+                                38.06228396667604
+                            ]
+                        },
+                        "ts": 1678637474.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 11,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:11:14.566166-04:00",
+                        "altitude": 256.8106629297274,
+                        "distance": 816.341627326976,
+                        "speed": 27.211387577565866,
+                        "heading": 133.80981748868788,
+                        "idx": 155,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa621"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.732067,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.732067-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.04452190213909,
+                        "longitude": -84.42130299569757,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.42130299569757,
+                                38.04452190213909
+                            ]
+                        },
+                        "ts": 1678637564.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 12,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:12:44.566166-04:00",
+                        "altitude": 257.9030244034572,
+                        "distance": 901.2308228081511,
+                        "speed": 30.041027426938367,
+                        "heading": 139.974941590312,
+                        "idx": 158,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa624"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.733653,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.733653-07:00"
+                    },
+                    "data": {
+                        "latitude": 38.02022726087744,
+                        "longitude": -84.41027609030577,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.41027609030577,
+                                38.02022726087744
+                            ]
+                        },
+                        "ts": 1678637654.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 14,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:14:14.566166-04:00",
+                        "altitude": 275.7670273898422,
+                        "distance": 996.9307666122673,
+                        "speed": 33.23102555374224,
+                        "heading": 146.5503503731601,
+                        "idx": 161,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa627"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.7357152,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.735715-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.99540504080786,
+                        "longitude": -84.39685493112117,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.39685493112117,
+                                37.99540504080786
+                            ]
+                        },
+                        "ts": 1678637744.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 15,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:15:44.566166-04:00",
+                        "altitude": 282.7799926016147,
+                        "distance": 1035.502226529689,
+                        "speed": 34.51674088432297,
+                        "heading": 156.6767906634573,
+                        "idx": 164,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa62a"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.737153,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.737153-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.96813351154103,
+                        "longitude": -84.38868898928952,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.38868898928952,
+                                37.96813351154103
+                            ]
+                        },
+                        "ts": 1678637834.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 17,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:17:14.566166-04:00",
+                        "altitude": 287.01459050393765,
+                        "distance": 1040.0049164056131,
+                        "speed": 34.666830546853774,
+                        "heading": 178.28253863301342,
+                        "idx": 167,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa62d"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.7388768,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.738877-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.94123630633544,
+                        "longitude": -84.3807319841945,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.3807319841945,
+                                37.94123630633544
+                            ]
+                        },
+                        "ts": 1678637924.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 18,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:18:44.566166-04:00",
+                        "altitude": 280.5683010953029,
+                        "distance": 1054.9840408070324,
+                        "speed": 35.16613469356775,
+                        "heading": 154.99786592803304,
+                        "idx": 170,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa630"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.7419672,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.741967-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.914126251439086,
+                        "longitude": -84.3643199708392,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.3643199708392,
+                                37.914126251439086
+                            ]
+                        },
+                        "ts": 1678638014.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 20,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:20:14.566166-04:00",
+                        "altitude": 241.48008415601953,
+                        "distance": 1133.0937303842313,
+                        "speed": 37.76979101280771,
+                        "heading": 153.20433740857652,
+                        "idx": 173,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa633"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.7438998,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.743900-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.88834034522501,
+                        "longitude": -84.34567119856656,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.34567119856656,
+                                37.88834034522501
+                            ]
+                        },
+                        "ts": 1678638104.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 21,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:21:44.566166-04:00",
+                        "altitude": 215.10593793392724,
+                        "distance": 1069.2515450187182,
+                        "speed": 35.641718167290605,
+                        "heading": 141.18876444072728,
+                        "idx": 176,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa636"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.745525,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.745525-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.865412635127356,
+                        "longitude": -84.33314542620272,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.33314542620272,
+                                37.865412635127356
+                            ]
+                        },
+                        "ts": 1678638194.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 23,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:23:14.566166-04:00",
+                        "altitude": 255.75672589039442,
+                        "distance": 1031.1653564260628,
+                        "speed": 34.37217854753543,
+                        "heading": 177.24199261078763,
+                        "idx": 179,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa639"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.747196,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.747196-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.83807011291766,
+                        "longitude": -84.32511547583141,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.32511547583141,
+                                37.83807011291766
+                            ]
+                        },
+                        "ts": 1678638284.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 24,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:24:44.566166-04:00",
+                        "altitude": 253.4820709150983,
+                        "distance": 1073.6476802579211,
+                        "speed": 35.78825600859737,
+                        "heading": 160.47091350730756,
+                        "idx": 182,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa63c"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.749988,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.749988-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.80802948332968,
+                        "longitude": -84.3247717939628,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.3247717939628,
+                                37.80802948332968
+                            ]
+                        },
+                        "ts": 1678638374.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 26,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:26:14.566166-04:00",
+                        "altitude": 236.2189656674251,
+                        "distance": 1108.1904438952433,
+                        "speed": 36.93968146317478,
+                        "heading": -178.87126400973338,
+                        "idx": 185,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa63f"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.751693,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.751693-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.77970403019157,
+                        "longitude": -84.31793348793748,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.31793348793748,
+                                37.77970403019157
+                            ]
+                        },
+                        "ts": 1678638464.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 27,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:27:44.566166-04:00",
+                        "altitude": 248.76022598593283,
+                        "distance": 1095.9172200756323,
+                        "speed": 36.53057400252108,
+                        "heading": 161.0702373238821,
+                        "idx": 188,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa642"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.753013,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.753013-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.75089082578557,
+                        "longitude": -84.32065887582336,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.32065887582336,
+                                37.75089082578557
+                            ]
+                        },
+                        "ts": 1678638554.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 29,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:29:14.566166-04:00",
+                        "altitude": 255.11337329254158,
+                        "distance": 1089.7102996198032,
+                        "speed": 36.32367665399344,
+                        "heading": -169.3786006815054,
+                        "idx": 191,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa645"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.7546089,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.754609-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.721819869887526,
+                        "longitude": -84.3225969172168,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.3225969172168,
+                                37.721819869887526
+                            ]
+                        },
+                        "ts": 1678638644.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 30,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:30:44.566166-04:00",
+                        "altitude": 240.351123000629,
+                        "distance": 1110.1669320277747,
+                        "speed": 37.00556440092582,
+                        "heading": 175.380193346995,
+                        "idx": 194,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa648"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.756178,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.756178-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.69221706710453,
+                        "longitude": -84.31560787179473,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.31560787179473,
+                                37.69221706710453
+                            ]
+                        },
+                        "ts": 1678638734.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 32,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:32:14.566166-04:00",
+                        "altitude": 235.93808897497783,
+                        "distance": 1118.471630052451,
+                        "speed": 37.28238766841503,
+                        "heading": 168.44091204704785,
+                        "idx": 197,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa64b"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.758257,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.758257-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.66399103909716,
+                        "longitude": -84.3113628417551,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.3113628417551,
+                                37.66399103909716
+                            ]
+                        },
+                        "ts": 1678638824.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 33,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:33:44.566166-04:00",
+                        "altitude": 273.99062292794554,
+                        "distance": 1069.3820481492921,
+                        "speed": 35.646068271643074,
+                        "heading": 178.24317931564005,
+                        "idx": 200,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa64e"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.7611861,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.761186-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.63502104913618,
+                        "longitude": -84.31617642617944,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.31617642617944,
+                                37.63502104913618
+                            ]
+                        },
+                        "ts": 1678638914.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 35,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:35:14.566166-04:00",
+                        "altitude": 259.408489796136,
+                        "distance": 1072.5896705840203,
+                        "speed": 35.75298901946734,
+                        "heading": -173.24678989783456,
+                        "idx": 203,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa651"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.762996,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.762996-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.60558137779279,
+                        "longitude": -84.31441496605206,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.31441496605206,
+                                37.60558137779279
+                            ]
+                        },
+                        "ts": 1678639004.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 36,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:36:44.566166-04:00",
+                        "altitude": 289.1131323006005,
+                        "distance": 1096.8097596060209,
+                        "speed": 36.5603253202007,
+                        "heading": 178.47724893785204,
+                        "idx": 206,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa654"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.764982,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.764982-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.57774070648325,
+                        "longitude": -84.31368684943978,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.31368684943978,
+                                37.57774070648325
+                            ]
+                        },
+                        "ts": 1678639094.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 38,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:38:14.566166-04:00",
+                        "altitude": 244.00780435323637,
+                        "distance": 1004.4530485333454,
+                        "speed": 33.48176828444485,
+                        "heading": -179.64190848984575,
+                        "idx": 209,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa657"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.766906,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.766906-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.54981769661694,
+                        "longitude": -84.31734901074721,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.31734901074721,
+                                37.54981769661694
+                            ]
+                        },
+                        "ts": 1678639184.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 39,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:39:44.566166-04:00",
+                        "altitude": 283.96094111467465,
+                        "distance": 1042.2207891951332,
+                        "speed": 34.74069297317111,
+                        "heading": -173.21934042504392,
+                        "idx": 212,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa65a"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.7686799,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.768680-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.519879551556684,
+                        "longitude": -84.3205616345074,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.3205616345074,
+                                37.519879551556684
+                            ]
+                        },
+                        "ts": 1678639274.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 41,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:41:14.566166-04:00",
+                        "altitude": 299.91053699304274,
+                        "distance": 1215.6379094696808,
+                        "speed": 40.52126364898936,
+                        "heading": 179.8795329084134,
+                        "idx": 215,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa65d"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.7702389,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.770239-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.489284089008784,
+                        "longitude": -84.33026433341648,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.33026433341648,
+                                37.489284089008784
+                            ]
+                        },
+                        "ts": 1678639364.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 42,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:42:44.566166-04:00",
+                        "altitude": 280.4704076495072,
+                        "distance": 1155.3640714693001,
+                        "speed": 38.51213571564334,
+                        "heading": -167.02944829972884,
+                        "idx": 218,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa660"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.772089,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.772089-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.460513967516434,
+                        "longitude": -84.33561550410556,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.33561550410556,
+                                37.460513967516434
+                            ]
+                        },
+                        "ts": 1678639454.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 44,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:44:14.566166-04:00",
+                        "altitude": 278.91036297510175,
+                        "distance": 1055.731049084309,
+                        "speed": 35.191034969476966,
+                        "heading": -176.45472080081154,
+                        "idx": 221,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa663"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.774025,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.774025-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.43196411338331,
+                        "longitude": -84.34243656759791,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.34243656759791,
+                                37.43196411338331
+                            ]
+                        },
+                        "ts": 1678639544.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 45,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:45:44.566166-04:00",
+                        "altitude": 323.8005781782112,
+                        "distance": 1070.7400102324254,
+                        "speed": 35.69133367441418,
+                        "heading": -165.52571813674712,
+                        "idx": 224,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa666"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.775775,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.775775-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.40312093899289,
+                        "longitude": -84.33898445718964,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.33898445718964,
+                                37.40312093899289
+                            ]
+                        },
+                        "ts": 1678639634.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 47,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:47:14.566166-04:00",
+                        "altitude": 329.9379921798048,
+                        "distance": 1101.1794616584796,
+                        "speed": 36.705982055282654,
+                        "heading": 171.5508153755769,
+                        "idx": 227,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa669"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.777364,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.777364-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.37617908166927,
+                        "longitude": -84.32782442490345,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.32782442490345,
+                                37.37617908166927
+                            ]
+                        },
+                        "ts": 1678639724.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 48,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:48:44.566166-04:00",
+                        "altitude": 289.19802965989146,
+                        "distance": 978.0909917123704,
+                        "speed": 32.60303305707901,
+                        "heading": 144.92207887364765,
+                        "idx": 230,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa66c"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.778371,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.778371-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.35305561490327,
+                        "longitude": -84.3078128437001,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.3078128437001,
+                                37.35305561490327
+                            ]
+                        },
+                        "ts": 1678639814.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 50,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:50:14.566166-04:00",
+                        "altitude": 322.94178708064595,
+                        "distance": 1087.6575588219969,
+                        "speed": 36.255251960733226,
+                        "heading": 168.31760411444742,
+                        "idx": 233,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa66f"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.779357,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.779357-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.32468176571899,
+                        "longitude": -84.3001586482537,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.3001586482537,
+                                37.32468176571899
+                            ]
+                        },
+                        "ts": 1678639904.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 51,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:51:44.566166-04:00",
+                        "altitude": 350.3857511764796,
+                        "distance": 1054.0776967239092,
+                        "speed": 35.13592322413031,
+                        "heading": 157.54522386310538,
+                        "idx": 236,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa672"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.780477,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.780477-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.30109397769284,
+                        "longitude": -84.28042296707385,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.28042296707385,
+                                37.30109397769284
+                            ]
+                        },
+                        "ts": 1678639994.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 53,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:53:14.566166-04:00",
+                        "altitude": 387.2324455568686,
+                        "distance": 1091.221869423772,
+                        "speed": 36.37406231412573,
+                        "heading": 139.89556667366455,
+                        "idx": 239,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa675"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.781458,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.781458-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.27663009401273,
+                        "longitude": -84.2560918880897,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.2560918880897,
+                                37.27663009401273
+                            ]
+                        },
+                        "ts": 1678640084.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 54,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:54:44.566166-04:00",
+                        "altitude": 334.0071451034881,
+                        "distance": 1181.9958732504103,
+                        "speed": 39.39986244168035,
+                        "heading": 146.05006586426111,
+                        "idx": 242,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa678"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.782413,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.782413-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.24670543103282,
+                        "longitude": -84.24492540749489,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.24492540749489,
+                                37.24670543103282
+                            ]
+                        },
+                        "ts": 1678640174.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 56,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:56:14.566166-04:00",
+                        "altitude": 259.29859427679156,
+                        "distance": 1120.3319582567287,
+                        "speed": 37.344398608557626,
+                        "heading": 163.49059982152798,
+                        "idx": 245,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa67b"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.783376,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.783376-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.22818404386838,
+                        "longitude": -84.21858716394784,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.21858716394784,
+                                37.22818404386838
+                            ]
+                        },
+                        "ts": 1678640264.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 57,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:57:44.566166-04:00",
+                        "altitude": 322.9114777555591,
+                        "distance": 1024.711218995681,
+                        "speed": 34.15704063318937,
+                        "heading": 127.66922813997148,
+                        "idx": 248,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa67e"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.784322,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.784322-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.21340811723602,
+                        "longitude": -84.18913416082846,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.18913416082846,
+                                37.21340811723602
+                            ]
+                        },
+                        "ts": 1678640354.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 59,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T12:59:14.566166-04:00",
+                        "altitude": 232.56085901844236,
+                        "distance": 987.8850209821945,
+                        "speed": 32.92950069940648,
+                        "heading": 111.64321059252751,
+                        "idx": 251,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa681"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.7852669,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.785267-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.201319739305305,
+                        "longitude": -84.1574634235478,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.1574634235478,
+                                37.201319739305305
+                            ]
+                        },
+                        "ts": 1678640444.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 13,
+                            "minute": 0,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T13:00:44.566166-04:00",
+                        "altitude": 319.5803879651463,
+                        "distance": 1062.0479363696784,
+                        "speed": 35.40159787898928,
+                        "heading": 121.13123744647385,
+                        "idx": 254,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa684"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.786211,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.786211-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.17973129330389,
+                        "longitude": -84.13403418976023,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.13403418976023,
+                                37.17973129330389
+                            ]
+                        },
+                        "ts": 1678640534.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 13,
+                            "minute": 2,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T13:02:14.566166-04:00",
+                        "altitude": 312.5533029488347,
+                        "distance": 1033.4902942306135,
+                        "speed": 34.44967647435378,
+                        "heading": 140.64087486579328,
+                        "idx": 257,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa687"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.787162,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.787162-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.157622683270496,
+                        "longitude": -84.11332167395419,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.11332167395419,
+                                37.157622683270496
+                            ]
+                        },
+                        "ts": 1678640624.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 13,
+                            "minute": 3,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T13:03:44.566166-04:00",
+                        "altitude": 303.8723042561854,
+                        "distance": 991.5691502658283,
+                        "speed": 33.05230500886094,
+                        "heading": 145.5880454182216,
+                        "idx": 260,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa68a"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.7882009,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.788201-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.130058509203316,
+                        "longitude": -84.10808903115253,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.10808903115253,
+                                37.130058509203316
+                            ]
+                        },
+                        "ts": 1678640714.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 13,
+                            "minute": 5,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T13:05:14.566166-04:00",
+                        "altitude": 344.9317823845316,
+                        "distance": 1029.9681716915352,
+                        "speed": 34.332272389717836,
+                        "heading": 171.07134315536277,
+                        "idx": 263,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa68d"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.790242,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.790242-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.1017628898624,
+                        "longitude": -84.10117459572258,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.10117459572258,
+                                37.1017628898624
+                            ]
+                        },
+                        "ts": 1678640804.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 13,
+                            "minute": 6,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T13:06:44.566166-04:00",
+                        "altitude": 348.8466845325888,
+                        "distance": 1102.5773662074625,
+                        "speed": 36.75257887358209,
+                        "heading": 171.69837399539804,
+                        "idx": 266,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa690"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.791562,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.791562-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.071596151737964,
+                        "longitude": -84.09900584958959,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.09900584958959,
+                                37.071596151737964
+                            ]
+                        },
+                        "ts": 1678640894.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 13,
+                            "minute": 8,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T13:08:14.566166-04:00",
+                        "altitude": 313.0608194787975,
+                        "distance": 1100.6632813352373,
+                        "speed": 36.68877604450791,
+                        "heading": 177.69714588389988,
+                        "idx": 269,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa693"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.792665,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.792665-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.04354759212407,
+                        "longitude": -84.09853279842395,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.09853279842395,
+                                37.04354759212407
+                            ]
+                        },
+                        "ts": 1678640984.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 13,
+                            "minute": 9,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T13:09:44.566166-04:00",
+                        "altitude": 266.41250574994643,
+                        "distance": 1012.2000378359228,
+                        "speed": 33.74000126119743,
+                        "heading": -179.6327446758712,
+                        "idx": 272,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa696"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.793757,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.793757-07:00"
+                    },
+                    "data": {
+                        "latitude": 37.0145323551561,
+                        "longitude": -84.10147925164077,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.10147925164077,
+                                37.0145323551561
+                            ]
+                        },
+                        "ts": 1678641074.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 13,
+                            "minute": 11,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T13:11:14.566166-04:00",
+                        "altitude": 298.48168797495134,
+                        "distance": 1045.1642200356307,
+                        "speed": 34.83880733452102,
+                        "heading": -171.70651443132672,
+                        "idx": 275,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa699"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.794742,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.794742-07:00"
+                    },
+                    "data": {
+                        "latitude": 36.986768830853144,
+                        "longitude": -84.1093972152604,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.1093972152604,
+                                36.986768830853144
+                            ]
+                        },
+                        "ts": 1678641164.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 13,
+                            "minute": 12,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T13:12:44.566166-04:00",
+                        "altitude": 332.52850047055915,
+                        "distance": 1036.05746082227,
+                        "speed": 34.53524869407567,
+                        "heading": -170.06793995056185,
+                        "idx": 278,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa69c"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.795722,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.795722-07:00"
+                    },
+                    "data": {
+                        "latitude": 36.97751582522692,
+                        "longitude": -84.11385692055507,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.11385692055507,
+                                36.97751582522692
+                            ]
+                        },
+                        "ts": 1678641254.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 13,
+                            "minute": 14,
+                            "second": 14,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T13:14:14.566166-04:00",
+                        "altitude": 317.4342397150014,
+                        "distance": 100.38171666614198,
+                        "speed": 3.346057222204733,
+                        "heading": -87.39707184065266,
+                        "idx": 281,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                },
+                {
+                    "_id": {
+                        "$oid": "642df8a67fb841b12dafa69f"
+                    },
+                    "user_id": {
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                    },
+                    "metadata": {
+                        "key": "analysis/recreated_location",
+                        "platform": "server",
+                        "write_ts": 1680734374.796803,
+                        "time_zone": "America/Los_Angeles",
+                        "write_local_dt": {
+                            "year": 2023,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 34,
+                            "weekday": 2,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "write_fmt_time": "2023-04-05T15:39:34.796803-07:00"
+                    },
+                    "data": {
+                        "latitude": 36.977774923599036,
+                        "longitude": -84.11608111637071,
+                        "loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -84.11608111637071,
+                                36.977774923599036
+                            ]
+                        },
+                        "ts": 1678641344.566166,
+                        "local_dt": {
+                            "year": 2023,
+                            "month": 3,
+                            "day": 12,
+                            "hour": 13,
+                            "minute": 15,
+                            "second": 44,
+                            "weekday": 6,
+                            "timezone": "America/New_York"
+                        },
+                        "fmt_time": "2023-03-12T13:15:44.566166-04:00",
+                        "altitude": 327.9704879699252,
+                        "distance": 5.100438267718337,
+                        "speed": 0.17001460892394457,
+                        "heading": -71.80097252177985,
+                        "idx": 284,
+                        "mode": 4,
+                        "section": {
+                            "$oid": "642df8a67fb841b12dafa582"
+                        }
+                    }
+                }
+            ],
+            "end_confirmed_place": {
+                "_id": {
+                    "$oid": "642df8ab7fb841b12dafa805"
+                },
+                "user_id": {
+                    "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                },
+                "metadata": {
+                    "key": "analysis/confirmed_place",
+                    "platform": "server",
+                    "write_ts": 1680734378.379153,
+                    "time_zone": "America/Los_Angeles",
+                    "write_local_dt": {
+                        "year": 2023,
+                        "month": 4,
+                        "day": 5,
+                        "hour": 15,
+                        "minute": 39,
+                        "second": 38,
+                        "weekday": 2,
+                        "timezone": "America/Los_Angeles"
+                    },
+                    "write_fmt_time": "2023-04-05T15:39:38.379153-07:00"
+                },
+                "data": {
+                    "source": "DwellSegmentationTimeFilter",
+                    "enter_ts": 1678641399.257,
+                    "enter_local_dt": {
+                        "year": 2023,
+                        "month": 3,
+                        "day": 12,
+                        "hour": 13,
+                        "minute": 16,
+                        "second": 39,
+                        "weekday": 6,
+                        "timezone": "America/New_York"
+                    },
+                    "enter_fmt_time": "2023-03-12T13:16:39.257000-04:00",
+                    "location": {
+                        "type": "Point",
+                        "coordinates": [
+                            -84.1162207,
+                            36.9776568
+                        ]
+                    },
+                    "raw_places": [
+                        {
+                            "$oid": "642df8a27fb841b12dafa570"
+                        },
+                        {
+                            "$oid": "642df8a27fb841b12dafa570"
+                        }
+                    ],
+                    "ending_trip": {
+                        "$oid": "642df8a57fb841b12dafa580"
+                    },
+                    "starting_trip": {
+                        "$oid": "642df8a77fb841b12dafa6a2"
+                    },
+                    "exit_ts": 1678642210.9015162,
+                    "exit_fmt_time": "2023-03-12T13:30:10.901516-04:00",
+                    "exit_local_dt": {
+                        "year": 2023,
+                        "month": 3,
+                        "day": 12,
+                        "hour": 13,
+                        "minute": 30,
+                        "second": 10,
+                        "weekday": 6,
+                        "timezone": "America/New_York"
+                    },
+                    "duration": 811.6445162296295,
+                    "cleaned_place": {
+                        "$oid": "642df8aa7fb841b12dafa7f0"
+                    },
+                    "user_input": {},
+                    "additions": []
+                }
+            }
+        }
+    },
+    {
+        "_id": {
+            "$oid": "642df8ad7fb841b12dafa80e"
+        },
+        "user_id": {
+            "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+        },
+        "metadata": {
+            "key": "analysis/composite_trip",
+            "platform": "server",
+            "write_ts": 1680734381.922267,
+            "time_zone": "America/Los_Angeles",
+            "write_local_dt": {
+                "year": 2023,
+                "month": 4,
+                "day": 5,
+                "hour": 15,
+                "minute": 39,
+                "second": 41,
+                "weekday": 2,
+                "timezone": "America/Los_Angeles"
+            },
+            "write_fmt_time": "2023-04-05T15:39:41.922267-07:00",
             "origin_key": "analysis/confirmed_trip"
         },
         "data": {
@@ -46,7 +5699,7 @@
                 ]
             },
             "raw_trip": {
-                "$oid": "6424f6c1faa2035f66392da1"
+                "$oid": "642df8a27fb841b12dafa571"
             },
             "start_ts": 1678642210.9015162,
             "start_local_dt": {
@@ -70,130 +5723,54 @@
             "duration": 8895.362483739853,
             "distance": 192292.6194098783,
             "start_place": {
-                "$oid": "6424f6c9faa2035f66393020"
+                "$oid": "642df8aa7fb841b12dafa7f0"
             },
             "end_place": {
-                "$oid": "6424f6c9faa2035f66393021"
+                "$oid": "642df8aa7fb841b12dafa7f1"
             },
             "cleaned_trip": {
-                "$oid": "6424f6c5faa2035f66392ed2"
+                "$oid": "642df8a77fb841b12dafa6a2"
             },
             "inferred_labels": [],
             "inferred_trip": {
-                "$oid": "6424f6cafaa2035f6639302a"
+                "$oid": "642df8aa7fb841b12dafa7fa"
             },
             "expectation": {
                 "to_label": true
             },
             "confidence_threshold": 0.55,
             "expected_trip": {
-                "$oid": "6424f6cafaa2035f66393032"
+                "$oid": "642df8ab7fb841b12dafa802"
             },
             "user_input": {},
             "additions": [],
             "confirmed_place": {
-                "_id": {
-                    "$oid": "6424f6ccfaa2035f66393037"
-                },
-                "user_id": {
-                    "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
-                },
-                "metadata": {
-                    "key": "analysis/confirmed_place",
-                    "platform": "server",
-                    "write_ts": 1680144073.473387,
-                    "time_zone": "America/Los_Angeles",
-                    "write_local_dt": {
-                        "year": 2023,
-                        "month": 3,
-                        "day": 29,
-                        "hour": 19,
-                        "minute": 41,
-                        "second": 13,
-                        "weekday": 2,
-                        "timezone": "America/Los_Angeles"
-                    },
-                    "write_fmt_time": "2023-03-29T19:41:13.473387-07:00"
-                },
-                "data": {
-                    "source": "DwellSegmentationTimeFilter",
-                    "enter_ts": 1678651106.264,
-                    "enter_local_dt": {
-                        "year": 2023,
-                        "month": 3,
-                        "day": 12,
-                        "hour": 15,
-                        "minute": 58,
-                        "second": 26,
-                        "weekday": 6,
-                        "timezone": "America/New_York"
-                    },
-                    "enter_fmt_time": "2023-03-12T15:58:26.264000-04:00",
-                    "location": {
-                        "type": "Point",
-                        "coordinates": [
-                            -83.4604138,
-                            35.7326732
-                        ]
-                    },
-                    "raw_places": [
-                        {
-                            "$oid": "6424f6c1faa2035f66392da2"
-                        },
-                        {
-                            "$oid": "6424f6c1faa2035f66392da2"
-                        }
-                    ],
-                    "ending_trip": {
-                        "$oid": "6424f6c5faa2035f66392ed2"
-                    },
-                    "starting_trip": {
-                        "$oid": "6424f6c7faa2035f66392fff"
-                    },
-                    "exit_ts": 1678651111.264,
-                    "exit_fmt_time": "2023-03-12T15:58:26.264000-04:00",
-                    "exit_local_dt": {
-                        "year": 2023,
-                        "month": 3,
-                        "day": 12,
-                        "hour": 15,
-                        "minute": 58,
-                        "second": 26,
-                        "weekday": 6,
-                        "timezone": "America/New_York"
-                    },
-                    "duration": 5.0,
-                    "cleaned_place": {
-                        "$oid": "6424f6c9faa2035f66393021"
-                    },
-                    "user_input": {},
-                    "additions": []
-                }
+                "$oid": "642df8ac7fb841b12dafa807"
             },
             "locations": [
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392ed5"
+                        "$oid": "642df8a87fb841b12dafa6a5"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.746273,
+                        "write_ts": 1680734376.245764,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.746273-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.245764-07:00"
                     },
                     "data": {
                         "latitude": 36.9776568,
@@ -224,33 +5801,33 @@
                         "idx": 0,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392ed8"
+                        "$oid": "642df8a87fb841b12dafa6a8"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.747583,
+                        "write_ts": 1680734376.246794,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.747583-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.246794-07:00"
                     },
                     "data": {
                         "latitude": 36.96056146635567,
@@ -281,33 +5858,33 @@
                         "idx": 3,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392edb"
+                        "$oid": "642df8a87fb841b12dafa6ab"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.749075,
+                        "write_ts": 1680734376.248985,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.749075-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.248985-07:00"
                     },
                     "data": {
                         "latitude": 36.943466132711336,
@@ -338,33 +5915,33 @@
                         "idx": 6,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392ede"
+                        "$oid": "642df8a87fb841b12dafa6ae"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.750753,
+                        "write_ts": 1680734376.250179,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.750753-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.250179-07:00"
                     },
                     "data": {
                         "latitude": 36.92637079906701,
@@ -395,33 +5972,33 @@
                         "idx": 9,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392ee1"
+                        "$oid": "642df8a87fb841b12dafa6b1"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.752804,
+                        "write_ts": 1680734376.2513258,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.752804-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.251326-07:00"
                     },
                     "data": {
                         "latitude": 36.90927546542268,
@@ -452,33 +6029,33 @@
                         "idx": 12,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392ee4"
+                        "$oid": "642df8a87fb841b12dafa6b4"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.754133,
+                        "write_ts": 1680734376.25233,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.754133-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.252330-07:00"
                     },
                     "data": {
                         "latitude": 36.89218013177835,
@@ -509,33 +6086,33 @@
                         "idx": 15,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392ee7"
+                        "$oid": "642df8a87fb841b12dafa6b7"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.755244,
+                        "write_ts": 1680734376.253451,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.755244-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.253451-07:00"
                     },
                     "data": {
                         "latitude": 36.87508479813402,
@@ -566,33 +6143,33 @@
                         "idx": 18,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392eea"
+                        "$oid": "642df8a87fb841b12dafa6ba"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.756165,
+                        "write_ts": 1680734376.2547011,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.756165-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.254701-07:00"
                     },
                     "data": {
                         "latitude": 36.85798946448969,
@@ -623,33 +6200,33 @@
                         "idx": 21,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392eed"
+                        "$oid": "642df8a87fb841b12dafa6bd"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.757051,
+                        "write_ts": 1680734376.256572,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.757051-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.256572-07:00"
                     },
                     "data": {
                         "latitude": 36.84089413084536,
@@ -680,33 +6257,33 @@
                         "idx": 24,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392ef0"
+                        "$oid": "642df8a87fb841b12dafa6c0"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.758656,
+                        "write_ts": 1680734376.25839,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.758656-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.258390-07:00"
                     },
                     "data": {
                         "latitude": 36.823798797201036,
@@ -737,33 +6314,33 @@
                         "idx": 27,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392ef3"
+                        "$oid": "642df8a87fb841b12dafa6c3"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.759776,
+                        "write_ts": 1680734376.260009,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.759776-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.260009-07:00"
                     },
                     "data": {
                         "latitude": 36.8067034635567,
@@ -794,33 +6371,33 @@
                         "idx": 30,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392ef6"
+                        "$oid": "642df8a87fb841b12dafa6c6"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.768223,
+                        "write_ts": 1680734376.261853,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.768223-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.261853-07:00"
                     },
                     "data": {
                         "latitude": 36.789608129912374,
@@ -851,33 +6428,33 @@
                         "idx": 33,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392ef9"
+                        "$oid": "642df8a87fb841b12dafa6c9"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.769515,
+                        "write_ts": 1680734376.263049,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.769515-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.263049-07:00"
                     },
                     "data": {
                         "latitude": 36.772512796268046,
@@ -908,33 +6485,33 @@
                         "idx": 36,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392efc"
+                        "$oid": "642df8a87fb841b12dafa6cc"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.770758,
+                        "write_ts": 1680734376.263999,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.770758-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.263999-07:00"
                     },
                     "data": {
                         "latitude": 36.75541746262372,
@@ -965,33 +6542,33 @@
                         "idx": 39,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392eff"
+                        "$oid": "642df8a87fb841b12dafa6cf"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.772769,
+                        "write_ts": 1680734376.265147,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.772769-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.265147-07:00"
                     },
                     "data": {
                         "latitude": 36.738322128979384,
@@ -1022,33 +6599,33 @@
                         "idx": 42,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f02"
+                        "$oid": "642df8a87fb841b12dafa6d2"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.773885,
+                        "write_ts": 1680734376.266072,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.773885-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.266072-07:00"
                     },
                     "data": {
                         "latitude": 36.71934124674562,
@@ -1079,33 +6656,33 @@
                         "idx": 45,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f05"
+                        "$oid": "642df8a87fb841b12dafa6d5"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.774793,
+                        "write_ts": 1680734376.267039,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.774793-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.267039-07:00"
                     },
                     "data": {
                         "latitude": 36.69595411150707,
@@ -1136,33 +6713,33 @@
                         "idx": 48,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f08"
+                        "$oid": "642df8a87fb841b12dafa6d8"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.777371,
+                        "write_ts": 1680734376.2681532,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.777371-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.268153-07:00"
                     },
                     "data": {
                         "latitude": 36.6717050298122,
@@ -1193,33 +6770,33 @@
                         "idx": 51,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f0b"
+                        "$oid": "642df8a87fb841b12dafa6db"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.77926,
+                        "write_ts": 1680734376.26913,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.779260-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.269130-07:00"
                     },
                     "data": {
                         "latitude": 36.64477386065004,
@@ -1250,33 +6827,33 @@
                         "idx": 54,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f0e"
+                        "$oid": "642df8a87fb841b12dafa6de"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.783824,
+                        "write_ts": 1680734376.27006,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.783824-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.270060-07:00"
                     },
                     "data": {
                         "latitude": 36.623009829075386,
@@ -1307,33 +6884,33 @@
                         "idx": 57,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f11"
+                        "$oid": "642df8a87fb841b12dafa6e1"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.7854762,
+                        "write_ts": 1680734376.2709918,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.785476-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.270992-07:00"
                     },
                     "data": {
                         "latitude": 36.596933590282724,
@@ -1364,33 +6941,33 @@
                         "idx": 60,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f14"
+                        "$oid": "642df8a87fb841b12dafa6e4"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.786648,
+                        "write_ts": 1680734376.2724102,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.786648-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.272410-07:00"
                     },
                     "data": {
                         "latitude": 36.57363367319572,
@@ -1421,33 +6998,33 @@
                         "idx": 63,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f17"
+                        "$oid": "642df8a87fb841b12dafa6e7"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.788831,
+                        "write_ts": 1680734376.273738,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.788831-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.273738-07:00"
                     },
                     "data": {
                         "latitude": 36.55423368209238,
@@ -1478,33 +7055,33 @@
                         "idx": 66,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f1a"
+                        "$oid": "642df8a87fb841b12dafa6ea"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.790177,
+                        "write_ts": 1680734376.2747421,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.790177-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.274742-07:00"
                     },
                     "data": {
                         "latitude": 36.53975331880637,
@@ -1535,33 +7112,33 @@
                         "idx": 69,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f1d"
+                        "$oid": "642df8a87fb841b12dafa6ed"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.7914681,
+                        "write_ts": 1680734376.2757068,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.791468-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.275707-07:00"
                     },
                     "data": {
                         "latitude": 36.522407086182994,
@@ -1592,33 +7169,33 @@
                         "idx": 72,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f20"
+                        "$oid": "642df8a87fb841b12dafa6f0"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.7926881,
+                        "write_ts": 1680734376.276777,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.792688-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.276777-07:00"
                     },
                     "data": {
                         "latitude": 36.5042187203314,
@@ -1649,33 +7226,33 @@
                         "idx": 75,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f23"
+                        "$oid": "642df8a87fb841b12dafa6f3"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.793836,
+                        "write_ts": 1680734376.277768,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.793836-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.277768-07:00"
                     },
                     "data": {
                         "latitude": 36.48176152588504,
@@ -1706,33 +7283,33 @@
                         "idx": 78,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f26"
+                        "$oid": "642df8a87fb841b12dafa6f6"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.7948642,
+                        "write_ts": 1680734376.2786932,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.794864-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.278693-07:00"
                     },
                     "data": {
                         "latitude": 36.46673002944339,
@@ -1763,33 +7340,33 @@
                         "idx": 81,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f29"
+                        "$oid": "642df8a87fb841b12dafa6f9"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.796308,
+                        "write_ts": 1680734376.2797272,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.796308-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.279727-07:00"
                     },
                     "data": {
                         "latitude": 36.45091293531902,
@@ -1820,33 +7397,33 @@
                         "idx": 84,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f2c"
+                        "$oid": "642df8a87fb841b12dafa6fc"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.7974458,
+                        "write_ts": 1680734376.280746,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.797446-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.280746-07:00"
                     },
                     "data": {
                         "latitude": 36.433608497813005,
@@ -1877,33 +7454,33 @@
                         "idx": 87,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f2f"
+                        "$oid": "642df8a87fb841b12dafa6ff"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.798757,
+                        "write_ts": 1680734376.281791,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.798757-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.281791-07:00"
                     },
                     "data": {
                         "latitude": 36.409941867621576,
@@ -1934,33 +7511,33 @@
                         "idx": 90,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f32"
+                        "$oid": "642df8a87fb841b12dafa702"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.799668,
+                        "write_ts": 1680734376.282736,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.799668-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.282736-07:00"
                     },
                     "data": {
                         "latitude": 36.38900346943204,
@@ -1991,33 +7568,33 @@
                         "idx": 93,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f35"
+                        "$oid": "642df8a87fb841b12dafa705"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.800767,
+                        "write_ts": 1680734376.283669,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.800767-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.283669-07:00"
                     },
                     "data": {
                         "latitude": 36.36572728190065,
@@ -2048,33 +7625,33 @@
                         "idx": 96,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f38"
+                        "$oid": "642df8a87fb841b12dafa708"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.802148,
+                        "write_ts": 1680734376.2846951,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.802148-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.284695-07:00"
                     },
                     "data": {
                         "latitude": 36.337717690150974,
@@ -2105,33 +7682,33 @@
                         "idx": 99,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f3b"
+                        "$oid": "642df8a87fb841b12dafa70b"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.803048,
+                        "write_ts": 1680734376.285683,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.803048-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.285683-07:00"
                     },
                     "data": {
                         "latitude": 36.31062298461413,
@@ -2162,33 +7739,33 @@
                         "idx": 102,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f3e"
+                        "$oid": "642df8a87fb841b12dafa70e"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.804317,
+                        "write_ts": 1680734376.286877,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.804317-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.286877-07:00"
                     },
                     "data": {
                         "latitude": 36.2919812708826,
@@ -2219,33 +7796,33 @@
                         "idx": 105,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f41"
+                        "$oid": "642df8a87fb841b12dafa711"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.8052852,
+                        "write_ts": 1680734376.287951,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.805285-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.287951-07:00"
                     },
                     "data": {
                         "latitude": 36.27054312065963,
@@ -2276,33 +7853,33 @@
                         "idx": 108,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f44"
+                        "$oid": "642df8a87fb841b12dafa714"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.806195,
+                        "write_ts": 1680734376.289244,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.806195-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.289244-07:00"
                     },
                     "data": {
                         "latitude": 36.247827721595804,
@@ -2333,33 +7910,33 @@
                         "idx": 111,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f47"
+                        "$oid": "642df8a87fb841b12dafa717"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.807178,
+                        "write_ts": 1680734376.29031,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.807178-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.290310-07:00"
                     },
                     "data": {
                         "latitude": 36.22977190206693,
@@ -2390,33 +7967,33 @@
                         "idx": 114,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f4a"
+                        "$oid": "642df8a87fb841b12dafa71a"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.8090339,
+                        "write_ts": 1680734376.291311,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.809034-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.291311-07:00"
                     },
                     "data": {
                         "latitude": 36.21038164686809,
@@ -2447,33 +8024,33 @@
                         "idx": 117,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f4d"
+                        "$oid": "642df8a87fb841b12dafa71d"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.8099751,
+                        "write_ts": 1680734376.292825,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.809975-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.292825-07:00"
                     },
                     "data": {
                         "latitude": 36.19277500894346,
@@ -2504,33 +8081,33 @@
                         "idx": 120,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f50"
+                        "$oid": "642df8a87fb841b12dafa720"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.811342,
+                        "write_ts": 1680734376.294102,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.811342-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.294102-07:00"
                     },
                     "data": {
                         "latitude": 36.17326665299219,
@@ -2561,33 +8138,33 @@
                         "idx": 123,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f53"
+                        "$oid": "642df8a87fb841b12dafa723"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.814361,
+                        "write_ts": 1680734376.295035,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.814361-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.295035-07:00"
                     },
                     "data": {
                         "latitude": 36.15249447664296,
@@ -2618,33 +8195,33 @@
                         "idx": 126,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f56"
+                        "$oid": "642df8a87fb841b12dafa726"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.815945,
+                        "write_ts": 1680734376.295954,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.815945-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.295954-07:00"
                     },
                     "data": {
                         "latitude": 36.135524583049865,
@@ -2675,33 +8252,33 @@
                         "idx": 129,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f59"
+                        "$oid": "642df8a87fb841b12dafa729"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.816917,
+                        "write_ts": 1680734376.296862,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.816917-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.296862-07:00"
                     },
                     "data": {
                         "latitude": 36.114297792587635,
@@ -2732,33 +8309,33 @@
                         "idx": 132,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f5c"
+                        "$oid": "642df8a87fb841b12dafa72c"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.817777,
+                        "write_ts": 1680734376.298065,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.817777-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.298065-07:00"
                     },
                     "data": {
                         "latitude": 36.09170075914726,
@@ -2789,33 +8366,33 @@
                         "idx": 135,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f5f"
+                        "$oid": "642df8a87fb841b12dafa72f"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.818665,
+                        "write_ts": 1680734376.2989929,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.818665-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.298993-07:00"
                     },
                     "data": {
                         "latitude": 36.07204665819653,
@@ -2846,33 +8423,33 @@
                         "idx": 138,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f62"
+                        "$oid": "642df8a87fb841b12dafa732"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.820131,
+                        "write_ts": 1680734376.2998998,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.820131-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.299900-07:00"
                     },
                     "data": {
                         "latitude": 36.049283630153454,
@@ -2903,33 +8480,33 @@
                         "idx": 141,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f65"
+                        "$oid": "642df8a87fb841b12dafa735"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.821484,
+                        "write_ts": 1680734376.3008142,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.821484-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.300814-07:00"
                     },
                     "data": {
                         "latitude": 36.02473652390269,
@@ -2960,33 +8537,33 @@
                         "idx": 144,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f68"
+                        "$oid": "642df8a87fb841b12dafa738"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.830212,
+                        "write_ts": 1680734376.3018649,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.830212-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.301865-07:00"
                     },
                     "data": {
                         "latitude": 36.0090392451832,
@@ -3017,33 +8594,33 @@
                         "idx": 147,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f6b"
+                        "$oid": "642df8a87fb841b12dafa73b"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.8317802,
+                        "write_ts": 1680734376.302783,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.831780-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.302783-07:00"
                     },
                     "data": {
                         "latitude": 35.99164894347051,
@@ -3074,33 +8651,33 @@
                         "idx": 150,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f6e"
+                        "$oid": "642df8a87fb841b12dafa73e"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.833513,
+                        "write_ts": 1680734376.304055,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.833513-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.304055-07:00"
                     },
                     "data": {
                         "latitude": 35.976516150352694,
@@ -3131,33 +8708,33 @@
                         "idx": 153,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f71"
+                        "$oid": "642df8a87fb841b12dafa741"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.834916,
+                        "write_ts": 1680734376.305155,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.834916-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.305155-07:00"
                     },
                     "data": {
                         "latitude": 35.963004707701,
@@ -3188,33 +8765,33 @@
                         "idx": 156,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f74"
+                        "$oid": "642df8a87fb841b12dafa744"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.8368661,
+                        "write_ts": 1680734376.306102,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.836866-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.306102-07:00"
                     },
                     "data": {
                         "latitude": 35.95560066645737,
@@ -3245,33 +8822,33 @@
                         "idx": 159,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f77"
+                        "$oid": "642df8a87fb841b12dafa747"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.839674,
+                        "write_ts": 1680734376.307144,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.839674-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.307144-07:00"
                     },
                     "data": {
                         "latitude": 35.94753786671942,
@@ -3302,33 +8879,33 @@
                         "idx": 162,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f7a"
+                        "$oid": "642df8a87fb841b12dafa74a"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.8409972,
+                        "write_ts": 1680734376.308107,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.840997-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.308107-07:00"
                     },
                     "data": {
                         "latitude": 35.93818629372164,
@@ -3359,33 +8936,33 @@
                         "idx": 165,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f7d"
+                        "$oid": "642df8a87fb841b12dafa74d"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.842096,
+                        "write_ts": 1680734376.309729,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.842096-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.309729-07:00"
                     },
                     "data": {
                         "latitude": 35.930448586413206,
@@ -3416,33 +8993,33 @@
                         "idx": 168,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f80"
+                        "$oid": "642df8a87fb841b12dafa750"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.843379,
+                        "write_ts": 1680734376.3107042,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.843379-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.310704-07:00"
                     },
                     "data": {
                         "latitude": 35.922637129075326,
@@ -3473,33 +9050,33 @@
                         "idx": 171,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f83"
+                        "$oid": "642df8a87fb841b12dafa753"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.8455412,
+                        "write_ts": 1680734376.3116422,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.845541-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.311642-07:00"
                     },
                     "data": {
                         "latitude": 35.92116807806996,
@@ -3530,33 +9107,33 @@
                         "idx": 174,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f86"
+                        "$oid": "642df8a87fb841b12dafa756"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.848557,
+                        "write_ts": 1680734376.312564,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.848557-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.312564-07:00"
                     },
                     "data": {
                         "latitude": 35.91167941312573,
@@ -3587,33 +9164,33 @@
                         "idx": 177,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f89"
+                        "$oid": "642df8a87fb841b12dafa759"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.849737,
+                        "write_ts": 1680734376.313482,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.849737-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.313482-07:00"
                     },
                     "data": {
                         "latitude": 35.907440964825085,
@@ -3644,33 +9221,33 @@
                         "idx": 180,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f8c"
+                        "$oid": "642df8a87fb841b12dafa75c"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.850687,
+                        "write_ts": 1680734376.314425,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.850687-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.314425-07:00"
                     },
                     "data": {
                         "latitude": 35.90308056292976,
@@ -3701,33 +9278,33 @@
                         "idx": 183,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f8f"
+                        "$oid": "642df8a87fb841b12dafa75f"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.8517141,
+                        "write_ts": 1680734376.315618,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.851714-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.315618-07:00"
                     },
                     "data": {
                         "latitude": 35.89491935686262,
@@ -3758,33 +9335,33 @@
                         "idx": 186,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f92"
+                        "$oid": "642df8a87fb841b12dafa762"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.852857,
+                        "write_ts": 1680734376.316556,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.852857-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.316556-07:00"
                     },
                     "data": {
                         "latitude": 35.8846606866267,
@@ -3815,33 +9392,33 @@
                         "idx": 189,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f95"
+                        "$oid": "642df8a87fb841b12dafa765"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.854142,
+                        "write_ts": 1680734376.317469,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.854142-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.317469-07:00"
                     },
                     "data": {
                         "latitude": 35.87917598209552,
@@ -3872,33 +9449,33 @@
                         "idx": 192,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f98"
+                        "$oid": "642df8a87fb841b12dafa768"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.8550222,
+                        "write_ts": 1680734376.3185909,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.855022-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.318591-07:00"
                     },
                     "data": {
                         "latitude": 35.872392047001185,
@@ -3929,33 +9506,33 @@
                         "idx": 195,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f9b"
+                        "$oid": "642df8a87fb841b12dafa76b"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.85594,
+                        "write_ts": 1680734376.319645,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.855940-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.319645-07:00"
                     },
                     "data": {
                         "latitude": 35.86465881604125,
@@ -3986,33 +9563,33 @@
                         "idx": 198,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392f9e"
+                        "$oid": "642df8a87fb841b12dafa76e"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.856873,
+                        "write_ts": 1680734376.320658,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.856873-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.320658-07:00"
                     },
                     "data": {
                         "latitude": 35.85847129995008,
@@ -4043,33 +9620,33 @@
                         "idx": 201,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fa1"
+                        "$oid": "642df8a87fb841b12dafa771"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.858142,
+                        "write_ts": 1680734376.3222558,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.858142-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.322256-07:00"
                     },
                     "data": {
                         "latitude": 35.851050255521336,
@@ -4100,33 +9677,33 @@
                         "idx": 204,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fa4"
+                        "$oid": "642df8a87fb841b12dafa774"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.8595798,
+                        "write_ts": 1680734376.323353,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.859580-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.323353-07:00"
                     },
                     "data": {
                         "latitude": 35.84961922547496,
@@ -4157,33 +9734,33 @@
                         "idx": 207,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fa7"
+                        "$oid": "642df8a87fb841b12dafa777"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.861417,
+                        "write_ts": 1680734376.324287,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.861417-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.324287-07:00"
                     },
                     "data": {
                         "latitude": 35.85886090576473,
@@ -4214,33 +9791,33 @@
                         "idx": 210,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392faa"
+                        "$oid": "642df8a87fb841b12dafa77a"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.862369,
+                        "write_ts": 1680734376.325313,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.862369-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.325313-07:00"
                     },
                     "data": {
                         "latitude": 35.86446684361431,
@@ -4271,33 +9848,33 @@
                         "idx": 213,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fad"
+                        "$oid": "642df8a87fb841b12dafa77d"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.864326,
+                        "write_ts": 1680734376.326603,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.864326-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.326603-07:00"
                     },
                     "data": {
                         "latitude": 35.854435466569555,
@@ -4328,33 +9905,33 @@
                         "idx": 216,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fb0"
+                        "$oid": "642df8a87fb841b12dafa780"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.865472,
+                        "write_ts": 1680734376.327578,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.865472-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.327578-07:00"
                     },
                     "data": {
                         "latitude": 35.85375912418342,
@@ -4385,33 +9962,33 @@
                         "idx": 219,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fb3"
+                        "$oid": "642df8a87fb841b12dafa783"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.866428,
+                        "write_ts": 1680734376.328502,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.866428-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.328502-07:00"
                     },
                     "data": {
                         "latitude": 35.84606177156681,
@@ -4442,33 +10019,33 @@
                         "idx": 222,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fb6"
+                        "$oid": "642df8a87fb841b12dafa786"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.867522,
+                        "write_ts": 1680734376.329417,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.867522-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.329417-07:00"
                     },
                     "data": {
                         "latitude": 35.83641949536176,
@@ -4499,33 +10076,33 @@
                         "idx": 225,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fb9"
+                        "$oid": "642df8a87fb841b12dafa789"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.869455,
+                        "write_ts": 1680734376.330336,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.869455-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.330336-07:00"
                     },
                     "data": {
                         "latitude": 35.82872650475188,
@@ -4556,33 +10133,33 @@
                         "idx": 228,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fbc"
+                        "$oid": "642df8a87fb841b12dafa78c"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.870333,
+                        "write_ts": 1680734376.331253,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.870333-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.331253-07:00"
                     },
                     "data": {
                         "latitude": 35.823237551525516,
@@ -4613,33 +10190,33 @@
                         "idx": 231,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fbf"
+                        "$oid": "642df8a87fb841b12dafa78f"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.871218,
+                        "write_ts": 1680734376.332431,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.871218-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.332431-07:00"
                     },
                     "data": {
                         "latitude": 35.81728410277864,
@@ -4670,33 +10247,33 @@
                         "idx": 234,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fc2"
+                        "$oid": "642df8a87fb841b12dafa792"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.872108,
+                        "write_ts": 1680734376.333366,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.872108-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.333366-07:00"
                     },
                     "data": {
                         "latitude": 35.81532672580136,
@@ -4727,33 +10304,33 @@
                         "idx": 237,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fc5"
+                        "$oid": "642df8a87fb841b12dafa795"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.872988,
+                        "write_ts": 1680734376.334275,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.872988-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.334275-07:00"
                     },
                     "data": {
                         "latitude": 35.808853210190414,
@@ -4784,33 +10361,33 @@
                         "idx": 240,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fc8"
+                        "$oid": "642df8a87fb841b12dafa798"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.874061,
+                        "write_ts": 1680734376.3353112,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.874061-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.335311-07:00"
                     },
                     "data": {
                         "latitude": 35.80502883207878,
@@ -4841,33 +10418,33 @@
                         "idx": 243,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fcb"
+                        "$oid": "642df8a87fb841b12dafa79b"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.8749802,
+                        "write_ts": 1680734376.336249,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.874980-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.336249-07:00"
                     },
                     "data": {
                         "latitude": 35.80042095584001,
@@ -4898,33 +10475,33 @@
                         "idx": 246,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fce"
+                        "$oid": "642df8a87fb841b12dafa79e"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.87605,
+                        "write_ts": 1680734376.337238,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.876050-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.337238-07:00"
                     },
                     "data": {
                         "latitude": 35.79284392266627,
@@ -4955,33 +10532,33 @@
                         "idx": 249,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fd1"
+                        "$oid": "642df8a87fb841b12dafa7a1"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.8779771,
+                        "write_ts": 1680734376.3390532,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.877977-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.339053-07:00"
                     },
                     "data": {
                         "latitude": 35.78329704952946,
@@ -5012,33 +10589,33 @@
                         "idx": 252,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fd4"
+                        "$oid": "642df8a87fb841b12dafa7a4"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.879755,
+                        "write_ts": 1680734376.340401,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.879755-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.340401-07:00"
                     },
                     "data": {
                         "latitude": 35.77603893235964,
@@ -5069,33 +10646,33 @@
                         "idx": 255,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fd7"
+                        "$oid": "642df8a87fb841b12dafa7a7"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.882813,
+                        "write_ts": 1680734376.341373,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.882813-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.341373-07:00"
                     },
                     "data": {
                         "latitude": 35.769419107512626,
@@ -5126,33 +10703,33 @@
                         "idx": 258,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fda"
+                        "$oid": "642df8a87fb841b12dafa7aa"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.8842869,
+                        "write_ts": 1680734376.34231,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.884287-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.342310-07:00"
                     },
                     "data": {
                         "latitude": 35.75670760663179,
@@ -5183,33 +10760,33 @@
                         "idx": 261,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fdd"
+                        "$oid": "642df8a87fb841b12dafa7ad"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.885524,
+                        "write_ts": 1680734376.343264,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.885524-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.343264-07:00"
                     },
                     "data": {
                         "latitude": 35.74501011657057,
@@ -5240,33 +10817,33 @@
                         "idx": 264,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fe0"
+                        "$oid": "642df8a87fb841b12dafa7b0"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.886441,
+                        "write_ts": 1680734376.344216,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.886441-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.344216-07:00"
                     },
                     "data": {
                         "latitude": 35.73460784731479,
@@ -5297,33 +10874,33 @@
                         "idx": 267,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fe3"
+                        "$oid": "642df8a87fb841b12dafa7b3"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.887551,
+                        "write_ts": 1680734376.3453948,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.887551-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.345395-07:00"
                     },
                     "data": {
                         "latitude": 35.72540220794887,
@@ -5354,33 +10931,33 @@
                         "idx": 270,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fe6"
+                        "$oid": "642df8a87fb841b12dafa7b6"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.888552,
+                        "write_ts": 1680734376.346524,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.888552-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.346524-07:00"
                     },
                     "data": {
                         "latitude": 35.71720278102573,
@@ -5411,33 +10988,33 @@
                         "idx": 273,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fe9"
+                        "$oid": "642df8a87fb841b12dafa7b9"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.8895948,
+                        "write_ts": 1680734376.347657,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.889595-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.347657-07:00"
                     },
                     "data": {
                         "latitude": 35.715267577379606,
@@ -5468,33 +11045,33 @@
                         "idx": 276,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fec"
+                        "$oid": "642df8a87fb841b12dafa7bc"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.890744,
+                        "write_ts": 1680734376.34863,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.890744-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.348630-07:00"
                     },
                     "data": {
                         "latitude": 35.71859241970194,
@@ -5525,33 +11102,33 @@
                         "idx": 279,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392fef"
+                        "$oid": "642df8a87fb841b12dafa7bf"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.891947,
+                        "write_ts": 1680734376.350424,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.891947-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.350424-07:00"
                     },
                     "data": {
                         "latitude": 35.72513039167476,
@@ -5582,33 +11159,33 @@
                         "idx": 282,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392ff2"
+                        "$oid": "642df8a87fb841b12dafa7c2"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.895263,
+                        "write_ts": 1680734376.35351,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.895263-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.353510-07:00"
                     },
                     "data": {
                         "latitude": 35.72626856949693,
@@ -5639,33 +11216,33 @@
                         "idx": 285,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392ff5"
+                        "$oid": "642df8a87fb841b12dafa7c5"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.8968031,
+                        "write_ts": 1680734376.355211,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.896803-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.355211-07:00"
                     },
                     "data": {
                         "latitude": 35.727154269086505,
@@ -5696,33 +11273,33 @@
                         "idx": 288,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392ff8"
+                        "$oid": "642df8a87fb841b12dafa7c8"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.89828,
+                        "write_ts": 1680734376.392151,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.898280-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.392151-07:00"
                     },
                     "data": {
                         "latitude": 35.732911413722356,
@@ -5753,33 +11330,33 @@
                         "idx": 291,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392ffb"
+                        "$oid": "642df8a87fb841b12dafa7cb"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.900332,
+                        "write_ts": 1680734376.394211,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.900332-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.394211-07:00"
                     },
                     "data": {
                         "latitude": 35.732627594088555,
@@ -5810,33 +11387,33 @@
                         "idx": 294,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c6faa2035f66392ffe"
+                        "$oid": "642df8a87fb841b12dafa7ce"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144070.902737,
+                        "write_ts": 1680734376.395319,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 10,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 36,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:10.902737-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:36.395319-07:00"
                     },
                     "data": {
                         "latitude": 35.7326732,
@@ -5867,36 +11444,115 @@
                         "idx": 297,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c6faa2035f66392ed4"
+                            "$oid": "642df8a87fb841b12dafa6a4"
                         }
                     }
                 }
-            ]
+            ],
+            "end_confirmed_place": {
+                "_id": {
+                    "$oid": "642df8ac7fb841b12dafa807"
+                },
+                "user_id": {
+                    "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                },
+                "metadata": {
+                    "key": "analysis/confirmed_place",
+                    "platform": "server",
+                    "write_ts": 1680734378.408201,
+                    "time_zone": "America/Los_Angeles",
+                    "write_local_dt": {
+                        "year": 2023,
+                        "month": 4,
+                        "day": 5,
+                        "hour": 15,
+                        "minute": 39,
+                        "second": 38,
+                        "weekday": 2,
+                        "timezone": "America/Los_Angeles"
+                    },
+                    "write_fmt_time": "2023-04-05T15:39:38.408201-07:00"
+                },
+                "data": {
+                    "source": "DwellSegmentationTimeFilter",
+                    "enter_ts": 1678651106.264,
+                    "enter_local_dt": {
+                        "year": 2023,
+                        "month": 3,
+                        "day": 12,
+                        "hour": 15,
+                        "minute": 58,
+                        "second": 26,
+                        "weekday": 6,
+                        "timezone": "America/New_York"
+                    },
+                    "enter_fmt_time": "2023-03-12T15:58:26.264000-04:00",
+                    "location": {
+                        "type": "Point",
+                        "coordinates": [
+                            -83.4604138,
+                            35.7326732
+                        ]
+                    },
+                    "raw_places": [
+                        {
+                            "$oid": "642df8a27fb841b12dafa572"
+                        },
+                        {
+                            "$oid": "642df8a27fb841b12dafa572"
+                        }
+                    ],
+                    "ending_trip": {
+                        "$oid": "642df8a77fb841b12dafa6a2"
+                    },
+                    "starting_trip": {
+                        "$oid": "642df8a87fb841b12dafa7cf"
+                    },
+                    "exit_ts": 1678651111.264,
+                    "exit_fmt_time": "2023-03-12T15:58:26.264000-04:00",
+                    "exit_local_dt": {
+                        "year": 2023,
+                        "month": 3,
+                        "day": 12,
+                        "hour": 15,
+                        "minute": 58,
+                        "second": 26,
+                        "weekday": 6,
+                        "timezone": "America/New_York"
+                    },
+                    "duration": 5.0,
+                    "cleaned_place": {
+                        "$oid": "642df8aa7fb841b12dafa7f1"
+                    },
+                    "user_input": {},
+                    "additions": []
+                }
+            }
         }
     },
     {
         "_id": {
-            "$oid": "6424f6cdfaa2035f6639303e"
+            "$oid": "642df8ad7fb841b12dafa80f"
         },
         "user_id": {
-            "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+            "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
         },
         "metadata": {
             "key": "analysis/composite_trip",
             "platform": "server",
-            "write_ts": 1680144071.062072,
+            "write_ts": 1680734381.976685,
             "time_zone": "America/Los_Angeles",
             "write_local_dt": {
                 "year": 2023,
-                "month": 3,
-                "day": 29,
-                "hour": 19,
-                "minute": 41,
-                "second": 11,
+                "month": 4,
+                "day": 5,
+                "hour": 15,
+                "minute": 39,
+                "second": 41,
                 "weekday": 2,
                 "timezone": "America/Los_Angeles"
             },
-            "write_fmt_time": "2023-03-29T19:41:11.062072-07:00",
+            "write_fmt_time": "2023-04-05T15:39:41.976685-07:00",
             "origin_key": "analysis/cleaned_untracked"
         },
         "data": {
@@ -5942,37 +11598,37 @@
             "duration": 7631.003999948502,
             "distance": 4469.499369190262,
             "start_place": {
-                "$oid": "6424f6c9faa2035f66393021"
+                "$oid": "642df8aa7fb841b12dafa7f1"
             },
             "end_place": {
-                "$oid": "6424f6c9faa2035f66393022"
+                "$oid": "642df8aa7fb841b12dafa7f2"
             },
             "locations": []
         }
     },
     {
         "_id": {
-            "$oid": "6424f6cefaa2035f6639303f"
+            "$oid": "642df8ae7fb841b12dafa810"
         },
         "user_id": {
-            "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+            "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
         },
         "metadata": {
             "key": "analysis/composite_trip",
             "platform": "server",
-            "write_ts": 1680144074.7363021,
+            "write_ts": 1680734382.144026,
             "time_zone": "America/Los_Angeles",
             "write_local_dt": {
                 "year": 2023,
-                "month": 3,
-                "day": 29,
-                "hour": 19,
-                "minute": 41,
-                "second": 14,
+                "month": 4,
+                "day": 5,
+                "hour": 15,
+                "minute": 39,
+                "second": 42,
                 "weekday": 2,
                 "timezone": "America/Los_Angeles"
             },
-            "write_fmt_time": "2023-03-29T19:41:14.736302-07:00",
+            "write_fmt_time": "2023-04-05T15:39:42.144026-07:00",
             "origin_key": "analysis/confirmed_trip"
         },
         "data": {
@@ -5997,7 +11653,7 @@
                 ]
             },
             "raw_trip": {
-                "$oid": "6424f6c1faa2035f66392da3"
+                "$oid": "642df8a27fb841b12dafa573"
             },
             "start_ts": 1678658742.268,
             "start_local_dt": {
@@ -6021,111 +11677,54 @@
             "duration": 788.0030000209808,
             "distance": 5365.3076466935945,
             "start_place": {
-                "$oid": "6424f6c9faa2035f66393022"
+                "$oid": "642df8aa7fb841b12dafa7f2"
             },
             "end_place": {
-                "$oid": "6424f6c9faa2035f66393023"
+                "$oid": "642df8aa7fb841b12dafa7f3"
             },
             "cleaned_trip": {
-                "$oid": "6424f6c7faa2035f66393000"
+                "$oid": "642df8a97fb841b12dafa7d0"
             },
             "inferred_labels": [],
             "inferred_trip": {
-                "$oid": "6424f6cafaa2035f6639302d"
+                "$oid": "642df8aa7fb841b12dafa7fd"
             },
             "expectation": {
                 "to_label": true
             },
             "confidence_threshold": 0.55,
             "expected_trip": {
-                "$oid": "6424f6cafaa2035f66393033"
+                "$oid": "642df8ab7fb841b12dafa803"
             },
             "user_input": {},
             "additions": [],
             "confirmed_place": {
-                "_id": {
-                    "$oid": "6424f6cdfaa2035f6639303a"
-                },
-                "user_id": {
-                    "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
-                },
-                "metadata": {
-                    "key": "analysis/confirmed_place",
-                    "platform": "server",
-                    "write_ts": 1680144073.502468,
-                    "time_zone": "America/Los_Angeles",
-                    "write_local_dt": {
-                        "year": 2023,
-                        "month": 3,
-                        "day": 29,
-                        "hour": 19,
-                        "minute": 41,
-                        "second": 13,
-                        "weekday": 2,
-                        "timezone": "America/Los_Angeles"
-                    },
-                    "write_fmt_time": "2023-03-29T19:41:13.502468-07:00"
-                },
-                "data": {
-                    "source": "DwellSegmentationTimeFilter",
-                    "enter_ts": 1678659530.271,
-                    "enter_local_dt": {
-                        "year": 2023,
-                        "month": 3,
-                        "day": 12,
-                        "hour": 18,
-                        "minute": 18,
-                        "second": 50,
-                        "weekday": 6,
-                        "timezone": "America/New_York"
-                    },
-                    "enter_fmt_time": "2023-03-12T18:18:50.271000-04:00",
-                    "location": {
-                        "type": "Point",
-                        "coordinates": [
-                            -83.4604075,
-                            35.7325579
-                        ]
-                    },
-                    "raw_places": [
-                        {
-                            "$oid": "6424f6c1faa2035f66392da4"
-                        }
-                    ],
-                    "ending_trip": {
-                        "$oid": "6424f6c7faa2035f66393000"
-                    },
-                    "cleaned_place": {
-                        "$oid": "6424f6c9faa2035f66393023"
-                    },
-                    "user_input": {},
-                    "additions": []
-                }
+                "$oid": "642df8ad7fb841b12dafa80a"
             },
             "locations": [
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f66393002"
+                        "$oid": "642df8a97fb841b12dafa7d2"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.338559,
+                        "write_ts": 1680734377.4616299,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.338559-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.461630-07:00"
                     },
                     "data": {
                         "latitude": 35.7158873,
@@ -6156,33 +11755,33 @@
                         "idx": 0,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f66393003"
+                        "$oid": "642df8a97fb841b12dafa7d3"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.338968,
+                        "write_ts": 1680734377.46234,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.338968-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.462340-07:00"
                     },
                     "data": {
                         "latitude": 35.71626895921081,
@@ -6213,33 +11812,33 @@
                         "idx": 1,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f66393004"
+                        "$oid": "642df8a97fb841b12dafa7d4"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.339553,
+                        "write_ts": 1680734377.462894,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.339553-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.462894-07:00"
                     },
                     "data": {
                         "latitude": 35.716218800390074,
@@ -6270,33 +11869,33 @@
                         "idx": 2,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f66393005"
+                        "$oid": "642df8a97fb841b12dafa7d5"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.340255,
+                        "write_ts": 1680734377.463428,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.340255-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.463428-07:00"
                     },
                     "data": {
                         "latitude": 35.71621015292626,
@@ -6327,33 +11926,33 @@
                         "idx": 3,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f66393006"
+                        "$oid": "642df8a97fb841b12dafa7d6"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.340728,
+                        "write_ts": 1680734377.464004,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.340728-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.464004-07:00"
                     },
                     "data": {
                         "latitude": 35.71623613242721,
@@ -6384,33 +11983,33 @@
                         "idx": 4,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f66393007"
+                        "$oid": "642df8a97fb841b12dafa7d7"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.3419678,
+                        "write_ts": 1680734377.464861,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.341968-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.464861-07:00"
                     },
                     "data": {
                         "latitude": 35.71628558000829,
@@ -6441,33 +12040,33 @@
                         "idx": 5,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f66393008"
+                        "$oid": "642df8a97fb841b12dafa7d8"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.342412,
+                        "write_ts": 1680734377.465688,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.342412-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.465688-07:00"
                     },
                     "data": {
                         "latitude": 35.716307957584974,
@@ -6498,33 +12097,33 @@
                         "idx": 6,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f66393009"
+                        "$oid": "642df8a97fb841b12dafa7d9"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.3429608,
+                        "write_ts": 1680734377.466252,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.342961-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.466252-07:00"
                     },
                     "data": {
                         "latitude": 35.71635322785511,
@@ -6555,33 +12154,33 @@
                         "idx": 7,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f6639300a"
+                        "$oid": "642df8a97fb841b12dafa7da"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.3435378,
+                        "write_ts": 1680734377.466787,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.343538-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.466787-07:00"
                     },
                     "data": {
                         "latitude": 35.71773159302342,
@@ -6612,33 +12211,33 @@
                         "idx": 8,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f6639300b"
+                        "$oid": "642df8a97fb841b12dafa7db"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.3440251,
+                        "write_ts": 1680734377.4673522,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.344025-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.467352-07:00"
                     },
                     "data": {
                         "latitude": 35.72132758011367,
@@ -6669,33 +12268,33 @@
                         "idx": 9,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f6639300c"
+                        "$oid": "642df8a97fb841b12dafa7dc"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.344372,
+                        "write_ts": 1680734377.4679449,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.344372-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.467945-07:00"
                     },
                     "data": {
                         "latitude": 35.7236387599223,
@@ -6726,33 +12325,33 @@
                         "idx": 10,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f6639300d"
+                        "$oid": "642df8a97fb841b12dafa7dd"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.3446772,
+                        "write_ts": 1680734377.4684758,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.344677-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.468476-07:00"
                     },
                     "data": {
                         "latitude": 35.72474163987639,
@@ -6783,33 +12382,33 @@
                         "idx": 11,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f6639300e"
+                        "$oid": "642df8a97fb841b12dafa7de"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.34528,
+                        "write_ts": 1680734377.468991,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.345280-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.468991-07:00"
                     },
                     "data": {
                         "latitude": 35.72681571910828,
@@ -6840,33 +12439,33 @@
                         "idx": 12,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f6639300f"
+                        "$oid": "642df8a97fb841b12dafa7df"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.345631,
+                        "write_ts": 1680734377.4695199,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.345631-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.469520-07:00"
                     },
                     "data": {
                         "latitude": 35.72660404846357,
@@ -6897,33 +12496,33 @@
                         "idx": 13,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f66393010"
+                        "$oid": "642df8a97fb841b12dafa7e0"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.3461828,
+                        "write_ts": 1680734377.470047,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.346183-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.470047-07:00"
                     },
                     "data": {
                         "latitude": 35.72624688498141,
@@ -6954,33 +12553,33 @@
                         "idx": 14,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f66393011"
+                        "$oid": "642df8a97fb841b12dafa7e1"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.346755,
+                        "write_ts": 1680734377.470562,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.346755-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.470562-07:00"
                     },
                     "data": {
                         "latitude": 35.72628636574426,
@@ -7011,33 +12610,33 @@
                         "idx": 15,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f66393012"
+                        "$oid": "642df8a97fb841b12dafa7e2"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.347359,
+                        "write_ts": 1680734377.471194,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.347359-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.471194-07:00"
                     },
                     "data": {
                         "latitude": 35.725792648487484,
@@ -7068,33 +12667,33 @@
                         "idx": 16,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f66393013"
+                        "$oid": "642df8a97fb841b12dafa7e3"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.34795,
+                        "write_ts": 1680734377.471591,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.347950-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.471591-07:00"
                     },
                     "data": {
                         "latitude": 35.7269034585205,
@@ -7125,33 +12724,33 @@
                         "idx": 17,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f66393014"
+                        "$oid": "642df8a97fb841b12dafa7e4"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.348499,
+                        "write_ts": 1680734377.473226,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.348499-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.473226-07:00"
                     },
                     "data": {
                         "latitude": 35.72922704919665,
@@ -7182,33 +12781,33 @@
                         "idx": 18,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f66393015"
+                        "$oid": "642df8a97fb841b12dafa7e5"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.349062,
+                        "write_ts": 1680734377.473823,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.349062-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.473823-07:00"
                     },
                     "data": {
                         "latitude": 35.73129708784927,
@@ -7239,33 +12838,33 @@
                         "idx": 19,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f66393016"
+                        "$oid": "642df8a97fb841b12dafa7e6"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.3496141,
+                        "write_ts": 1680734377.4743612,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.349614-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.474361-07:00"
                     },
                     "data": {
                         "latitude": 35.73274168265989,
@@ -7296,33 +12895,33 @@
                         "idx": 20,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f66393017"
+                        "$oid": "642df8a97fb841b12dafa7e7"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.35093,
+                        "write_ts": 1680734377.4754791,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.350930-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.475479-07:00"
                     },
                     "data": {
                         "latitude": 35.73328709367622,
@@ -7353,33 +12952,33 @@
                         "idx": 21,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f66393018"
+                        "$oid": "642df8a97fb841b12dafa7e8"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.351638,
+                        "write_ts": 1680734377.476054,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.351638-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.476054-07:00"
                     },
                     "data": {
                         "latitude": 35.7329730726965,
@@ -7410,33 +13009,33 @@
                         "idx": 22,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f66393019"
+                        "$oid": "642df8a97fb841b12dafa7e9"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.352124,
+                        "write_ts": 1680734377.476616,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.352124-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.476616-07:00"
                     },
                     "data": {
                         "latitude": 35.732653980112985,
@@ -7467,33 +13066,33 @@
                         "idx": 23,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f6639301a"
+                        "$oid": "642df8a97fb841b12dafa7ea"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.352586,
+                        "write_ts": 1680734377.47718,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.352586-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.477180-07:00"
                     },
                     "data": {
                         "latitude": 35.73254786317377,
@@ -7524,33 +13123,33 @@
                         "idx": 24,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f6639301b"
+                        "$oid": "642df8a97fb841b12dafa7eb"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.3551428,
+                        "write_ts": 1680734377.477875,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.355143-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.477875-07:00"
                     },
                     "data": {
                         "latitude": 35.73252843683448,
@@ -7581,33 +13180,33 @@
                         "idx": 25,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f6639301c"
+                        "$oid": "642df8a97fb841b12dafa7ec"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.355804,
+                        "write_ts": 1680734377.478459,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.355804-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.478459-07:00"
                     },
                     "data": {
                         "latitude": 35.73255042978629,
@@ -7638,33 +13237,33 @@
                         "idx": 26,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 },
                 {
                     "_id": {
-                        "$oid": "6424f6c8faa2035f6639301d"
+                        "$oid": "642df8a97fb841b12dafa7ed"
                     },
                     "user_id": {
-                        "$uuid": "7e923ca2c4f24acb83c5fa89fce2d2d0"
+                        "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
                     },
                     "metadata": {
                         "key": "analysis/recreated_location",
                         "platform": "server",
-                        "write_ts": 1680144072.356817,
+                        "write_ts": 1680734377.479069,
                         "time_zone": "America/Los_Angeles",
                         "write_local_dt": {
                             "year": 2023,
-                            "month": 3,
-                            "day": 29,
-                            "hour": 19,
-                            "minute": 41,
-                            "second": 12,
+                            "month": 4,
+                            "day": 5,
+                            "hour": 15,
+                            "minute": 39,
+                            "second": 37,
                             "weekday": 2,
                             "timezone": "America/Los_Angeles"
                         },
-                        "write_fmt_time": "2023-03-29T19:41:12.356817-07:00"
+                        "write_fmt_time": "2023-04-05T15:39:37.479069-07:00"
                     },
                     "data": {
                         "latitude": 35.7325579,
@@ -7695,11 +13294,71 @@
                         "idx": 27,
                         "mode": 4,
                         "section": {
-                            "$oid": "6424f6c8faa2035f66393001"
+                            "$oid": "642df8a97fb841b12dafa7d1"
                         }
                     }
                 }
-            ]
+            ],
+            "end_confirmed_place": {
+                "_id": {
+                    "$oid": "642df8ad7fb841b12dafa80a"
+                },
+                "user_id": {
+                    "$uuid": "0b891fc9d8c34453ba64b910c8eb910c"
+                },
+                "metadata": {
+                    "key": "analysis/confirmed_place",
+                    "platform": "server",
+                    "write_ts": 1680734378.4452338,
+                    "time_zone": "America/Los_Angeles",
+                    "write_local_dt": {
+                        "year": 2023,
+                        "month": 4,
+                        "day": 5,
+                        "hour": 15,
+                        "minute": 39,
+                        "second": 38,
+                        "weekday": 2,
+                        "timezone": "America/Los_Angeles"
+                    },
+                    "write_fmt_time": "2023-04-05T15:39:38.445234-07:00"
+                },
+                "data": {
+                    "source": "DwellSegmentationTimeFilter",
+                    "enter_ts": 1678659530.271,
+                    "enter_local_dt": {
+                        "year": 2023,
+                        "month": 3,
+                        "day": 12,
+                        "hour": 18,
+                        "minute": 18,
+                        "second": 50,
+                        "weekday": 6,
+                        "timezone": "America/New_York"
+                    },
+                    "enter_fmt_time": "2023-03-12T18:18:50.271000-04:00",
+                    "location": {
+                        "type": "Point",
+                        "coordinates": [
+                            -83.4604075,
+                            35.7325579
+                        ]
+                    },
+                    "raw_places": [
+                        {
+                            "$oid": "642df8a27fb841b12dafa574"
+                        }
+                    ],
+                    "ending_trip": {
+                        "$oid": "642df8a97fb841b12dafa7d0"
+                    },
+                    "cleaned_place": {
+                        "$oid": "642df8aa7fb841b12dafa7f3"
+                    },
+                    "user_input": {},
+                    "additions": []
+                }
+            }
         }
     }
 ]


### PR DESCRIPTION
Because of https://github.com/shankari/e-mission-server/pull/9, we should expect 4 composite trips. The previous expectation file only had 3.

Because of https://github.com/shankari/e-mission-server/pull/10, it also needed to compare outputs using `end_confirmed_place` instead of `confirmed_place`